### PR TITLE
Modified installation parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 
  
 cmake_minimum_required (VERSION 2.8.11)
-project( GrPPI )
+project( grppi )
 
 
 # Define a path for modules before accesing default. Needed to find TBB
@@ -223,7 +223,7 @@ add_subdirectory(docs)
 
 # DESTINATION gets the previous path and appends the argument --> /opt/local/GrPPI
 
-# cmake -DCMAKE_INSTALL_PREFIX=path/to/folder
+# cmake .. -DCMAKE_INSTALL_PREFIX=path/to/folder
 
 #llvm --> cmake -DCMAKE_INSTALL_PREFIX=/tmp/llvm 
 
@@ -231,9 +231,9 @@ add_subdirectory(docs)
 # g++ farm1.cpp -I /tmp/GrPPI -std=c++14 -lboost_system -lboost_thread
 
 # Installation -- make install
-install ( DIRECTORY ${PROJECT_SOURCE_DIR}/include DESTINATION  "${CMAKE_PROJECT_NAME}" )
+install ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION  "include/${CMAKE_PROJECT_NAME}" )
 # Installation of fastflow
-install ( DIRECTORY ${PROJECT_SOURCE_DIR}/fastflow DESTINATION "${CMAKE_PROJECT_NAME}" )
+# install ( DIRECTORY ${PROJECT_SOURCE_DIR}/fastflow DESTINATION "${CMAKE_PROJECT_NAME}" )
 
 #install( FILES ${PPIHEADERS_CPU} DESTINATION /include/include/ )
 #install( FILES ${PPIHEADERS_GPU} DESTINATION /include/include/ )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,64 +179,9 @@ endif( CUDA_ENABLE )
 # Doxygen Documentation
 add_subdirectory(docs)
 
-# # PPI
-# set( PPI ${PROJECT_SOURCE_DIR}/include )
-
-# set( PPIHEADERS_CPU
-# #SEQ
-#      ${PPI}/ppi_seq/divideandconquer_seq.hpp
-#      ${PPI}/ppi_seq/farm_seq.hpp
-#      ${PPI}/ppi_seq/mapreduce_seq.hpp
-#      ${PPI}/ppi_seq/map_seq.hpp
-#      ${PPI}/ppi_seq/pipeline_seq.hpp
-#      ${PPI}/ppi_seq/reduce_seq.hpp
-#      ${PPI}/ppi_seq/stencil_seq.hpp
-#      ${PPI}/ppi_seq/stream_filter_seq.hpp
-#      ${PPI}/ppi_seq/stream_reduce_seq.hpp
-# #OMP
-#      ${PPI}/ppi_omp/farm_omp.hpp
-#      ${PPI}/ppi_omp/pipeline_omp.hpp
-#      ${PPI}/ppi_omp/stream_filter_omp.hpp
-#      ${PPI}/ppi_omp/stream_reduce_omp.hpp
-# #THR
-#      ${PPI}/ppi_thr/divideandconquer_thr.hpp
-#      ${PPI}/ppi_thr/farm_thr.hpp
-#      ${PPI}/ppi_thr/mapreduce_thr.hpp
-#      ${PPI}/ppi_thr/map_thr.hpp
-#      ${PPI}/ppi_thr/pipeline_thr.hpp
-#      ${PPI}/ppi_thr/reduce_thr.hpp
-#      ${PPI}/ppi_thr/stencil_thr.hpp
-#      ${PPI}/ppi_thr/stream_filter_thr.hpp
-#      ${PPI}/ppi_thr/stream_reduce_thr.hpp
-# #TBB
-#      ${PPI}/ppi_tbb/farm_tbb.hpp
-#      ${PPI}/ppi_tbb/pipeline_tbb.hpp
-# )
-
-
-# If BUILD_TESTS is ON, the test will be created before the installation is performed.
-
-# Default installation path
-#set (CMAKE_INSTALL_PREFIX "/opt/")
-# DESTDIR takes a value and appends to it the CMAKE_INSTALL_PREFIX
-# make install DESTDIR=/local --> /local/opt
-
-# DESTINATION gets the previous path and appends the argument --> /opt/local/GrPPI
-
-# cmake .. -DCMAKE_INSTALL_PREFIX=path/to/folder
-
-#llvm --> cmake -DCMAKE_INSTALL_PREFIX=/tmp/llvm 
-
-# To compile once installed
-# g++ farm1.cpp -I /tmp/GrPPI -std=c++14 -lboost_system -lboost_thread
-
-# Installation -- make install
-install ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION  "include/${CMAKE_PROJECT_NAME}" )
-# Installation of fastflow
-# install ( DIRECTORY ${PROJECT_SOURCE_DIR}/fastflow DESTINATION "${CMAKE_PROJECT_NAME}" )
-
-#install( FILES ${PPIHEADERS_CPU} DESTINATION /include/include/ )
-#install( FILES ${PPIHEADERS_GPU} DESTINATION /include/include/ )
+# Installation
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION "include/${CMAKE_PROJECT_NAME}"
+        FILES_MATCHING PATTERN "*.h")
 
 include_directories("${CMAKE_SOURCE_DIR}/include")
 


### PR DESCRIPTION
Removed fastflow installation attempt.
Modified the installation path to "include/grppi".
The project name in CMake has been renamed from "GrPPI" to "grppi".

By default the installation folder is /home/lab1/include/grppi.
With cmake .. -DCMAKE_INSTALL_PREFIX=path/to/folder it will install the files in path/to/folder/include/grppi