### PR TITLE
Add basic numa infrastructure and improve thread policy - Issue 19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,7 @@ find_package(HWLOC)
 if(HWLOC_FOUND)
     add_definitions( "-DGRPPI_HWLOC" )
 else()
-
-     message( FATAL_ERROR "Boost library is not installed in your system" )    
+     message( WARNING "hwloc library is not installed in your system" )    
 endif()
 # Create header file with the XX_ENABLE flags
 #set (HEADER_FILE "include/enable_flags.hpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,13 @@ else()
 	message( FATAL_ERROR "Boost library is not installed in your system" )    
 endif()
 
+find_package(HWLOC)
+if(HWLOC_FOUND)
+    add_definitions( "-DGRPPI_HWLOC" )
+else()
 
+     message( FATAL_ERROR "Boost library is not installed in your system" )    
+endif()
 # Create header file with the XX_ENABLE flags
 #set (HEADER_FILE "include/enable_flags.hpp")
 #file (WRITE ${HEADER_FILE} "//Enable Flags")

--- a/FindHWLOC.cmake
+++ b/FindHWLOC.cmake
@@ -1,0 +1,207 @@
+#.rst:
+# FindHwloc
+# ----------
+#
+# Try to find Portable Hardware Locality (hwloc) libraries.
+# http://www.open-mpi.org/software/hwloc
+#
+# You may declare HWLOC_ROOT environment variable to tell where
+# your hwloc library is installed. 
+#
+# Once done this will define::
+#
+#   Hwloc_FOUND            - True if hwloc was found
+#   Hwloc_INCLUDE_DIRS     - include directories for hwloc
+#   Hwloc_LIBRARIES        - link against these libraries to use hwloc
+#   Hwloc_VERSION          - version
+#   Hwloc_CFLAGS           - include directories as compiler flags
+#   Hwloc_LDLFAGS          - link paths and libs as compiler flags
+#
+
+#=============================================================================
+# Copyright 2014 Mikael Lepistö
+#
+# Distributed under the OSI-approved BSD License (the "License");
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+if(WIN32)
+  find_path(Hwloc_INCLUDE_DIR
+    NAMES
+      hwloc.h
+    PATHS
+      ENV "PROGRAMFILES(X86)"
+      ENV HWLOC_ROOT
+    PATH_SUFFIXES
+      include
+  )
+
+  find_library(Hwloc_LIBRARY
+    NAMES 
+      libhwloc.lib
+    PATHS
+      ENV "PROGRAMFILES(X86)"
+      ENV HWLOC_ROOT
+    PATH_SUFFIXES
+      lib
+  )
+
+  #
+  # Check if the found library can be used to linking 
+  #
+  SET (_TEST_SOURCE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/linktest.c")
+  FILE (WRITE "${_TEST_SOURCE}"
+    "
+    #include <hwloc.h>
+    int main()
+    { 
+      hwloc_topology_t topology;
+      int nbcores;
+      hwloc_topology_init(&topology);
+      hwloc_topology_load(topology);
+      nbcores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+      hwloc_topology_destroy(topology);
+      return 0;
+    }
+    "
+  )
+
+  TRY_COMPILE(_LINK_SUCCESS ${CMAKE_BINARY_DIR} "${_TEST_SOURCE}"
+    CMAKE_FLAGS
+    "-DINCLUDE_DIRECTORIES:STRING=${Hwloc_INCLUDE_DIR}"
+    CMAKE_FLAGS
+    "-DLINK_LIBRARIES:STRING=${Hwloc_LIBRARY}"
+  )
+
+  IF(NOT _LINK_SUCCESS)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      message(STATUS "You are building 64bit target.")
+    ELSE()
+      message(STATUS "You are building 32bit code. If you like to build x64 use e.g. -G 'Visual Studio 12 Win64' generator." )
+    ENDIF()
+    message(FATAL_ERROR "Library found, but linking test program failed.")
+  ENDIF()
+
+  #
+  # Resolve version if some compiled binary found...
+  #
+  find_program(HWLOC_INFO_EXECUTABLE
+    NAMES 
+      hwloc-info
+    PATHS
+      ENV HWLOC_ROOT 
+    PATH_SUFFIXES
+      bin
+  )
+  
+  if(HWLOC_INFO_EXECUTABLE)
+    execute_process(
+      COMMAND ${HWLOC_INFO_EXECUTABLE} "--version" 
+      OUTPUT_VARIABLE HWLOC_VERSION_LINE 
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REGEX MATCH "([0-9]+.[0-9]+)$" 
+      Hwloc_VERSION "${HWLOC_VERSION_LINE}")
+    unset(HWLOC_VERSION_LINE)
+  endif()
+  
+  #
+  # All good
+  #
+
+  set(Hwloc_LIBRARIES ${Hwloc_LIBRARY})
+  set(Hwloc_INCLUDE_DIRS ${Hwloc_INCLUDE_DIR})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    Hwloc
+    FOUND_VAR Hwloc_FOUND
+    REQUIRED_VARS Hwloc_LIBRARY Hwloc_INCLUDE_DIR
+    VERSION_VAR Hwloc_VERSION)
+
+  mark_as_advanced(
+    Hwloc_INCLUDE_DIR
+    Hwloc_LIBRARY)
+
+  foreach(arg ${Hwloc_INCLUDE_DIRS})
+    set(Hwloc_CFLAGS "${Hwloc_CFLAGS} /I${arg}")
+  endforeach()
+
+  set(Hwloc_LDFLAGS "${Hwloc_LIBRARY}")
+
+else()
+
+  if(CMAKE_CROSSCOMPILING)
+
+  find_path(Hwloc_INCLUDE_DIRS
+    NAMES
+      hwloc.h
+    PATHS
+      ENV HWLOC_ROOT
+  )
+
+  find_library(Hwloc_LIBRARIES
+    NAMES
+      hwloc
+    PATHS
+      ENV HWLOC_ROOT
+  )
+
+  if(Hwloc_INCLUDE_DIRS AND Hwloc_LIBRARIES)
+    message(WARNING "HWLOC library found using find_library() - cannot determine version. Assuming 1.7.0")
+    set(Hwloc_FOUND 1)
+    set(Hwloc_VERSION "1.7.0")
+  endif()
+
+  else() # Find with pkgconfig for non-crosscompile builds
+
+  find_package(PkgConfig)
+
+  if(HWLOC_ROOT)
+    set(ENV{PKG_CONFIG_PATH} "${HWLOC_ROOT}/lib/pkgconfig")
+  else()
+    foreach(PREFIX ${CMAKE_PREFIX_PATH})
+      set(PKG_CONFIG_PATH "${PKG_CONFIG_PATH}:${PREFIX}/lib/pkgconfig")
+    endforeach()
+    set(ENV{PKG_CONFIG_PATH} "${PKG_CONFIG_PATH}:$ENV{PKG_CONFIG_PATH}")
+  endif()
+
+  if(hwloc_FIND_REQUIRED)
+    set(_hwloc_OPTS "REQUIRED")
+  elseif(hwloc_FIND_QUIETLY)
+    set(_hwloc_OPTS "QUIET")
+  else()
+    set(_hwloc_output 1)
+  endif()
+
+  if(hwloc_FIND_VERSION)
+    if(hwloc_FIND_VERSION_EXACT)
+      pkg_check_modules(Hwloc ${_hwloc_OPTS} hwloc=${hwloc_FIND_VERSION})
+    else()
+      pkg_check_modules(Hwloc ${_hwloc_OPTS} hwloc>=${hwloc_FIND_VERSION})
+    endif()
+  else()
+    pkg_check_modules(Hwloc ${_hwloc_OPTS} hwloc)
+  endif()
+
+  if(Hwloc_FOUND)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(Hwloc DEFAULT_MSG Hwloc_LIBRARIES)
+
+    if(NOT ${Hwloc_VERSION} VERSION_LESS 1.7.0)
+      set(Hwloc_GL_FOUND 1)
+    endif()
+
+    if(_hwloc_output)
+      message(STATUS
+        "Found hwloc ${Hwloc_VERSION} in ${Hwloc_INCLUDE_DIRS}:${Hwloc_LIBRARIES}")
+    endif()
+  endif()
+
+  endif() # cross-compile else
+
+endif()
+

--- a/include/common/omp_policy.h
+++ b/include/common/omp_policy.h
@@ -29,29 +29,51 @@ namespace grppi{
  *    implementation 
  */
 struct parallel_execution_omp{
-  bool ordering = true;
-  bool lockfree = false;
-  int num_threads = 4;
-  int get_threadID(){
+  private:
+   bool ordering = true;
+   bool lockfree = false;
+   int num_threads = 4;
+  public:
+   void set_lockfree(bool value){ lockfree = value;}
+   void set_ordered(bool value){ ordering = value;}
+
+   bool is_lockfree(){ return lockfree;}
+   bool is_ordered(){ return ordering;}
+
+   /** @brief Set num_threads to _threads to a new value
+   *
+   *  @param _threads number of threads 
+   */
+   void set_num_threads(int _nthreads){
+     num_threads = _nthreads;
+   };
+   /** @brief returns the number of threads
+    */
+   int get_num_threads() const{
+     return num_threads;
+   };
+
+
+   int get_threadID(){
      return omp_get_thread_num();
-  }
-  /** @brief Set num_threads to the maximum number of thread available by the
-   *    hardware
-   */
-  parallel_execution_omp(){};
-
-  /** @brief Set num_threads to _threads in order to run in parallel
-   *
-   *  @param _threads number of threads used in the parallel mode
-   */
-  parallel_execution_omp(int _threads){num_threads=_threads; };
-
-  /** @brief Set num_threads to _threads in order to run in parallel and allows to disable the ordered execution
-   *
-   *  @param _threads number of threads used in the parallel mode
-   *  @param _order enable or disable the ordered execution
-   */
-  parallel_execution_omp(int _threads, bool order){ num_threads=_threads; ordering = order;};
+   }
+   /** @brief Set num_threads to the maximum number of thread available by the
+    *    hardware
+    */
+   parallel_execution_omp(){};
+ 
+   /** @brief Set num_threads to _threads in order to run in parallel
+    *
+    *  @param _threads number of threads used in the parallel mode
+    */
+   parallel_execution_omp(int _threads){num_threads=_threads; };
+  
+   /** @brief Set num_threads to _threads in order to run in parallel and allows to disable the ordered execution
+    *
+    *  @param _threads number of threads used in the parallel mode
+    *  @param _order enable or disable the ordered execution
+    */
+   parallel_execution_omp(int _threads, bool order){ num_threads=_threads; ordering = order;};
 
 };
 

--- a/include/common/seq_policy.h
+++ b/include/common/seq_policy.h
@@ -25,11 +25,22 @@ namespace grppi{
 
 /** @brief Set the execution mode to sequencial */
 struct sequential_execution {
-  bool ordering = true;
-  int num_threads=1;
-  bool lockfree = false;
-  /** @brief set num_threads to 1 in order to sequential execution */
-  sequential_execution(){};
+  private:
+    bool ordering = true;
+    int num_threads=1;
+    bool lockfree = false;
+  public:
+    /** @brief set num_threads to 1 in order to sequential execution */
+    sequential_execution(){};
+
+    //Empty functions. Only for potability among framewoks 
+    inline bool is_lockfree(){ return false;}
+    inline bool is_ordered(){ return true;}
+    inline void set_lockfree(bool value){ }
+    inline void set_ordered(bool value){ }
+    inline void set_num_threads(int _nthreads){ }
+    inline int get_num_threads() const{ return 1;}
+
 };
 
 } // end namespace grppi

--- a/include/common/tbb_policy.h
+++ b/include/common/tbb_policy.h
@@ -27,20 +27,40 @@ namespace grppi{
  *    (TBB) framework implementation
  */
 struct parallel_execution_tbb{
-  bool ordering = true;
-  bool lockfree = false;
-  int num_threads = 4;
-  int num_tokens = 100;
-  /** @brief Set num_threads to the maximum number of thread available by the
-   *    hardware
-   */
-  parallel_execution_tbb(){};
+  private:
+    bool ordering = true;
+    bool lockfree = false;
+    int num_threads = 4;
+  public:
+    int num_tokens = 100;
+    void set_lockfree(bool value){ lockfree = value;}
+    void set_ordered(bool value){ ordering = value;}
 
-  /** @brief Set num_threads to _threads in order to run in parallel
+    bool is_lockfree(){ return lockfree;}
+    bool is_ordered(){ return ordering;}
+    
+     /** @brief Set num_threads to _threads to a new value
    *
-   *  @param _threads number of threads used in the parallel mode
+   *  @param _threads number of threads 
    */
-  parallel_execution_tbb(int _threads){ num_threads= _threads; };
+   void set_num_threads(int _nthreads){
+     num_threads = _nthreads;
+   };
+   /** @brief returns the number of threads
+    */
+   int get_num_threads() const{
+     return num_threads;
+   };
+   /** @brief Set num_threads to the maximum number of thread available by the
+    *    hardware
+    */
+   parallel_execution_tbb(){};
+ 
+   /** @brief Set num_threads to _threads in order to run in parallel
+    *
+    *  @param _threads number of threads used in the parallel mode
+    */
+   parallel_execution_tbb(int _threads){ num_threads= _threads; };
 };
 
 } // end namespace grppi

--- a/include/common/thread_policy.h
+++ b/include/common/thread_policy.h
@@ -22,6 +22,13 @@
 #define GRPPI_THREAD_POLICY_H
 
 #include "../ppi_thr/pool.h"
+
+#ifdef GRPPI_HWLOC
+#include <hwloc.h>
+#endif
+
+#include <tuple>
+#include <map>
 #include <thread>
 #include <atomic>
 #include <algorithm>
@@ -34,52 +41,180 @@ namespace grppi {
 /** @brief Set the execution mode to parallel with posix thread implementation 
  */
 struct parallel_execution_thr {
-  public: 
-  thread_pool pool;
-  bool ordering = true;
-  int num_threads = 4;
-  bool lockfree = false;
+  private:
+   //NUMA and CPU affinity 
+   #ifdef GRPPI_HWLOC
+   hwloc_topology_t topo;
+   std::map<int, hwloc_bitmap_t > cpu_bind;
+   std::map<int, hwloc_bitmap_t > mem_bind;
+   #endif
+   //Number of threads, current active threads and their IDs
+   int num_threads;
+   int active_threads = 0;
+   std::vector<std::thread::id> thid_table;
+   std::atomic_flag lock = ATOMIC_FLAG_INIT;
+   thread_pool pool;
+   bool lockfree = false;
+   bool ordering = false;
 
-  int get_threadID(){
-      while (lock.test_and_set(std::memory_order_acquire));
-      auto it = std::find(thid_table.begin(), thid_table.end(), std::this_thread::get_id());
-      auto id = std::distance(thid_table.begin(), it);
-      lock.clear(std::memory_order_release);  
-      return id; 
-  }
-  
-  void register_thread(){
-      while (lock.test_and_set(std::memory_order_acquire));
-      thid_table.push_back(std::this_thread::get_id());    
-      lock.clear(std::memory_order_release);  
-  }
-  
-  void deregister_thread(){
-      while (lock.test_and_set(std::memory_order_acquire));
-      thid_table.erase(std::remove(thid_table.begin(), thid_table.end(),std::this_thread::get_id()), thid_table.end());
-      lock.clear(std::memory_order_release);  
-  }
-  /** @brief Set num_threads to the maximum number of thread available by the
-   *    hardware
+   //Apply the user defined CPU and NUMA affinity
+   void apply_affinity(int tid)
+   {
+   #ifdef GRPPI_HWLOC
+     auto thr_mask = cpu_bind.find(tid);
+     if(cpu_bind.end() != thr_mask){
+       hwloc_set_cpubind( topo, thr_mask->second, HWLOC_CPUBIND_THREAD );
+     }
+     auto mem_mask = mem_bind.find(tid);
+     if(mem_bind.end() != mem_mask){
+       hwloc_set_membind_nodeset(topo, mem_mask->second, HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_THREAD);
+     }
+   #endif
+   };
+
+ public:
+   //Enables the output ordering and the use of lockfree queues
+   void set_lockfree(bool value){ lockfree = value;}
+   void set_ordered(bool value){ ordering = value;}
+   
+   bool is_lockfree(){ return lockfree;}
+   bool is_ordered(){ return ordering;}
+   
+   //Create a new task for the thread pool 
+   template <typename T>
+   void create_task(T task){ pool.create_task(task);}
+
+   //Register a new active thread
+   void register_thread(){
+     while (lock.test_and_set(std::memory_order_acquire));
+     active_threads++;
+     thid_table.push_back(std::this_thread::get_id());
+     auto it = std::find(thid_table.begin(), thid_table.end(), std::this_thread::get_id());
+     auto id = std::distance(thid_table.begin(), it);
+     lock.clear(std::memory_order_release);
+     apply_affinity(id);
+   }
+
+   /** @brief returns the ID of the current thread 
    */
-  parallel_execution_thr(){ /*if(!initialised)*/ pool.initialise(this->num_threads); };
+   int get_threadID(){
+     while (lock.test_and_set(std::memory_order_acquire));
+     auto it = std::find(thid_table.begin(), thid_table.end(), std::this_thread::get_id());
+     auto id = std::distance(thid_table.begin(), it);
+     lock.clear(std::memory_order_release);
+     return id;
+   }
 
-  /** @brief Set num_threads to _threads in order to run in parallel
-   *
-   *  @param _threads number of threads used in the parallel mode
+   //Deregister a thread
+    void deregister_thread(){
+     while (lock.test_and_set(std::memory_order_acquire));
+     active_threads--;
+     if(active_threads == 0) thid_table.clear();
+     lock.clear(std::memory_order_release);
+   }
+
+   /** @brief Set num_threads to the maximum number of thread available by the
+    *    hardware
+    */
+   parallel_execution_thr(){
+   #ifdef GRPPI_HWLOC
+     hwloc_topology_init(&topo);
+     hwloc_topology_load(topo);
+   #endif
+     num_threads = std::thread::hardware_concurrency();
+     pool.initialise(num_threads);
+   };
+
+   /** @brief Set num_threads to _threads in order to run in parallel
+    *
+    *  @param _threads number of threads used in the parallel mode
    */
-  parallel_execution_thr(int _threads){ num_threads=_threads;  pool.initialise (_threads);};
+   parallel_execution_thr(int _nthreads){
+   #ifdef GRPPI_HWLOC
+    hwloc_topology_init(&topo);
+    hwloc_topology_load(topo);
+   #endif
+    num_threads = _nthreads;
+    pool.initialise(num_threads);
+   };
 
-  /** @brief Set num_threads to _threads in order to run in parallel and allows to disable the ordered execution
-   *
-   *  @param _threads number of threads used in the parallel mode
-   *  @param _order enable or disable the ordered execution
-   */
-  parallel_execution_thr(int _threads, bool order){ num_threads=_threads; ordering = order; pool.initialise (_threads);};
-  private: 
-     std::atomic_flag lock = ATOMIC_FLAG_INIT;
-     std::vector<std::thread::id> thid_table;
 
+
+   /** @brief Set num_threads to _threads in order to run in parallel and allows to disable the ordered execution
+    *
+    *  @param _threads number of threads used in the parallel mode
+    *  @param _order enable or disable the ordered execution
+    */
+   parallel_execution_thr(int _nthreads, bool order){
+   #ifdef GRPPI_HWLOC
+     hwloc_topology_init(&topo);
+     hwloc_topology_load(topo);
+   #endif
+     num_threads = _nthreads;
+     pool.initialise(num_threads);
+     ordering = order;
+   };
+
+   ~parallel_execution_thr(){
+   #ifdef GRPPI_HWLOC
+     for(auto it = cpu_bind.begin(); it != cpu_bind.end(); it++) hwloc_bitmap_free(it->second);
+     for(auto it = mem_bind.begin(); it != mem_bind.end(); it++) hwloc_bitmap_free(it->second);
+     hwloc_topology_destroy(topo);
+   #endif
+   };
+
+   /** @brief Set num_threads to _threads to a new value
+    *
+    *  @param _threads number of threads 
+    */
+   inline void set_num_threads(int _nthreads){
+   #ifdef GRPPI_HWLOC
+     for(auto i = _nthreads; i< num_threads;i++){
+       auto cit = cpu_bind.find(i);
+       if(cit != cpu_bind.end()) hwloc_bitmap_free(cit->second);
+       cpu_bind.erase(i);
+       auto nit = mem_bind.find(i);
+       if(nit != mem_bind.end()) hwloc_bitmap_free(nit->second);
+       mem_bind.erase(i);
+     }
+   #endif
+     num_threads = _nthreads;
+   };
+   /** @brief returns the number of threads
+    */
+   inline int get_num_threads() const{
+     return num_threads;
+   };
+   /** @brief Set the memory affinity of a given thread to a set of NUMA nodes
+    *
+    *  @param tid ID of the thread that should be pinned
+    *  @param nodeset vector of NUMA nodes IDs 
+    */
+   inline void set_numa_affinity(int tid, std::vector<int> nodeset){
+   #ifdef GRPPI_HWLOC
+     unsigned int length = nodeset.size();
+     hwloc_bitmap_t numa_set = hwloc_bitmap_alloc();
+     for(auto i = 0; i < length; i++){
+       hwloc_bitmap_set( numa_set, nodeset[i] );
+     }
+     mem_bind[tid] = numa_set;
+   #endif
+   };
+   /** @brief Set the CPU affinity of a given thread to a set of CPU nodes
+    *
+    *  @param tid ID of the thread that should be pinned
+    *  @param cpuset vector of CPU IDs 
+    */
+   inline void set_thread_affinity(int tid, std::vector<int> cpuset){
+   #ifdef GRPPI_HWLOC
+     unsigned int length = cpuset.size();
+     hwloc_bitmap_t cpu_set = hwloc_bitmap_alloc();
+     for(auto i = 0; i < length; i++){
+       hwloc_bitmap_set( cpu_set, cpuset[i] );
+     }
+     cpu_bind[tid] = cpu_set;
+   #endif
+   };
 };
 } // end namespace grppi
 

--- a/include/common/thread_policy.h
+++ b/include/common/thread_policy.h
@@ -106,7 +106,7 @@ struct parallel_execution_thr {
    }
 
    //Deregister a thread
-    void deregister_thread(){
+   void deregister_thread(){
      while (lock.test_and_set(std::memory_order_acquire));
      active_threads--;
      if(active_threads == 0) thid_table.clear();
@@ -167,7 +167,7 @@ struct parallel_execution_thr {
     *
     *  @param _threads number of threads 
     */
-   inline void set_num_threads(int _nthreads){
+   void set_num_threads(int _nthreads){
    #ifdef GRPPI_HWLOC
      for(auto i = _nthreads; i< num_threads;i++){
        auto cit = cpu_bind.find(i);
@@ -182,7 +182,7 @@ struct parallel_execution_thr {
    };
    /** @brief returns the number of threads
     */
-   inline int get_num_threads() const{
+   int get_num_threads() const{
      return num_threads;
    };
    /** @brief Set the memory affinity of a given thread to a set of NUMA nodes
@@ -190,7 +190,7 @@ struct parallel_execution_thr {
     *  @param tid ID of the thread that should be pinned
     *  @param nodeset vector of NUMA nodes IDs 
     */
-   inline void set_numa_affinity(int tid, std::vector<int> nodeset){
+   void set_numa_affinity(int tid, std::vector<int> nodeset){
    #ifdef GRPPI_HWLOC
      unsigned int length = nodeset.size();
      hwloc_bitmap_t numa_set = hwloc_bitmap_alloc();
@@ -205,7 +205,7 @@ struct parallel_execution_thr {
     *  @param tid ID of the thread that should be pinned
     *  @param cpuset vector of CPU IDs 
     */
-   inline void set_thread_affinity(int tid, std::vector<int> cpuset){
+   void set_thread_affinity(int tid, std::vector<int> cpuset){
    #ifdef GRPPI_HWLOC
      unsigned int length = cpuset.size();
      hwloc_bitmap_t cpu_set = hwloc_bitmap_alloc();

--- a/include/ppi_omp/divideandconquer_omp.h
+++ b/include/ppi_omp/divideandconquer_omp.h
@@ -74,7 +74,7 @@ inline void internal_divide_and_conquer(parallel_execution_omp p, Input & proble
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
 inline void divide_and_conquer(parallel_execution_omp p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge) {
-    std::atomic<int> num_threads( p.num_threads );
+    std::atomic<int> num_threads( p.get_num_threads() );
 
     if(num_threads.load()>0){
        auto subproblems = divide(problem);

--- a/include/ppi_omp/farm_omp.h
+++ b/include/ppi_omp/farm_omp.h
@@ -28,13 +28,13 @@ using namespace std;
 template <typename GenFunc, typename TaskFunc>
 void farm(parallel_execution_omp p, GenFunc const &in, TaskFunc const &taskf) {
 	
-    Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.lockfree);
+    Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.is_lockfree());
     #pragma omp parallel
     {
 	#pragma omp single nowait
 	{
             //Create threads
-            for( int i = 0; i < p.num_threads; i++ ) {
+            for( int i = 0; i < p.get_num_threads(); i++ ) {
                 #pragma omp task shared(queue)
 		{
                     typename std::result_of<GenFunc()>::type item;
@@ -51,7 +51,7 @@ void farm(parallel_execution_omp p, GenFunc const &in, TaskFunc const &taskf) {
                 auto k = in();
                 queue.push( k ) ;
                 if( !k ) {
-                    for( int i = 1; i < p.num_threads; i++ )
+                    for( int i = 1; i < p.get_num_threads(); i++ )
                         queue.push(k);
                     break;
                 }

--- a/include/ppi_omp/pipeline_omp.h
+++ b/include/ppi_omp/pipeline_omp.h
@@ -32,7 +32,7 @@ void stages( parallel_execution_omp p, Stream& st, Stage const& s ){
     typename Stream::value_type item;
     std::vector<typename Stream::value_type> elements;
     long current = 0;
-    if(p.ordering){
+    if(p.is_ordered()){
       item = st.pop( );
       while( item.first ) {
         if(current == item.second){
@@ -73,11 +73,11 @@ void stages( parallel_execution_omp p, Stream& st, Stage const& s ){
 
 template <typename Task, typename Stream,typename... Stages>
 inline void stages( parallel_execution_omp p, Stream& st, FilterObj<parallel_execution_omp, Task>& se, Stages ... sgs ) {
-    if(p.ordering){
+    if(p.is_ordered()){
        Queue< typename Stream::value_type > q(DEFAULT_SIZE);
 
        std::atomic<int> nend ( 0 );
-       for( int th = 0; th < se.exectype->num_threads; th++){
+       for( int th = 0; th < se.exectype->get_num_threads(); th++){
            #pragma omp task shared(q,se,st,nend)
            {
                  typename Stream::value_type item;
@@ -91,7 +91,7 @@ inline void stages( parallel_execution_omp p, Stream& st, FilterObj<parallel_exe
                      item = st.pop();
                  }
                  nend++;
-                 if(nend == se.exectype->num_threads){
+                 if(nend == se.exectype->get_num_threads()){
                     q.push( std::make_pair(typename Stream::value_type::first_type(), -1) );
                  }else{
                     st.push(item);
@@ -153,7 +153,7 @@ inline void stages( parallel_execution_omp p, Stream& st, FilterObj<parallel_exe
        Queue< typename Stream::value_type > q(DEFAULT_SIZE);
 
        std::atomic<int> nend ( 0 );
-       for( int th = 0; th < se.exectype->num_threads; th++){
+       for( int th = 0; th < se.exectype->get_num_threads(); th++){
              #pragma omp task shared(q,se,st,nend)
              {
                  typename Stream::value_type item;
@@ -167,7 +167,7 @@ inline void stages( parallel_execution_omp p, Stream& st, FilterObj<parallel_exe
                       item = st.pop();
                  }
                  nend++;
-                 if(nend == se.exectype->num_threads){
+                 if(nend == se.exectype->get_num_threads()){
                     q.push( std::make_pair(typename Stream::value_type::first_type(), -1) );
                  }else{
                     st.push(item);
@@ -189,7 +189,7 @@ inline void stages( parallel_execution_omp p, Stream& st, FarmObj<parallel_execu
    
     Queue< std::pair < optional < typename std::result_of< Task(typename Stream::value_type::first_type::value_type) >::type >, long > > q(DEFAULT_SIZE);
     std::atomic<int> nend ( 0 );
-    for( int th = 0; th < se.exectype->num_threads; th++){
+    for( int th = 0; th < se.exectype->get_num_threads(); th++){
       #pragma omp task shared(nend,q,se,st)
       {
          auto item = st.pop();
@@ -201,7 +201,7 @@ inline void stages( parallel_execution_omp p, Stream& st, FarmObj<parallel_execu
         }
         st.push(item);
         nend++;
-        if(nend == se.exectype->num_threads)
+        if(nend == se.exectype->get_num_threads())
           q.push(make_pair(optional< typename std::result_of< Task(typename Stream::value_type::first_type::value_type) >::type >(), -1));
       }              
     }

--- a/include/ppi_omp/stencil_omp.h
+++ b/include/ppi_omp/stencil_omp.h
@@ -27,18 +27,18 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 inline void stencil(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
 
     int numElements = last - first;
-    int elemperthr = numElements/p.num_threads;
+    int elemperthr = numElements/p.get_num_threads();
     #pragma omp parallel
     {
     #pragma omp single nowait
     { 
-    for(int i=1;i<p.num_threads;i++){
+    for(int i=1;i<p.get_num_threads();i++){
        #pragma omp task firstprivate(i)
        {
          auto begin = first + (elemperthr * i);
          auto end = first + (elemperthr * (i+1));
       
-         if( i == p.num_threads-1) end = last;
+         if( i == p.get_num_threads()-1) end = last;
 
          auto out = firstOut + (elemperthr * i);
 
@@ -69,19 +69,19 @@ template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Tas
 inline void stencil(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
 
      int numElements = last - first;
-     int elemperthr = numElements/p.num_threads;
+     int elemperthr = numElements/p.get_num_threads();
      #pragma omp parallel 
      {
      #pragma omp single nowait
      {
 
-     for(int i=1;i<p.num_threads;i++){
+     for(int i=1;i<p.get_num_threads();i++){
         #pragma omp task firstprivate(i)// firstprivate(inputs...)
         {
            auto begin = first + (elemperthr * i);
            auto end = first + (elemperthr * (i+1));
 
-	       if(i==p.num_threads-1) end = last;
+	       if(i==p.get_num_threads()-1) end = last;
 
            auto out = firstOut + (elemperthr * i);
         

--- a/include/ppi_tbb/divideandconquer_tbb.h
+++ b/include/ppi_tbb/divideandconquer_tbb.h
@@ -75,7 +75,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 inline void divide_and_conquer(parallel_execution_tbb p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge) {
 
-    std::atomic<int> num_threads( p.num_threads );
+    std::atomic<int> num_threads( p.get_num_threads() );
 
     if(num_threads.load()>0){
        auto subproblems = divide(problem);

--- a/include/ppi_tbb/farm_tbb.h
+++ b/include/ppi_tbb/farm_tbb.h
@@ -27,11 +27,11 @@ template <typename GenFunc, typename TaskFunc, typename SinkFunc>
 inline void farm(parallel_execution_tbb p, GenFunc const &in, TaskFunc const & taskf , SinkFunc const &sink) {
 
     tbb::task_group g;
-    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.lockfree);
-    Queue< optional < typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(DEFAULT_SIZE,p.lockfree);
+    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.is_lockfree());
+    Queue< optional < typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(DEFAULT_SIZE,p.is_lockfree());
     //Create threads
     std::atomic<int>nend(0);
-    for( int i = 0; i < p.num_threads; i++ ) {
+    for( int i = 0; i < p.get_num_threads(); i++ ) {
        g.run(
           [&](){
              typename std::result_of<GenFunc()>::type item;
@@ -42,7 +42,7 @@ inline void farm(parallel_execution_tbb p, GenFunc const &in, TaskFunc const & t
                item = queue.pop(  );
              }
              nend++;
-             if(nend == p.num_threads)
+             if(nend == p.get_num_threads())
                  queueout.push( optional< typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type >() );
 
          }
@@ -67,7 +67,7 @@ inline void farm(parallel_execution_tbb p, GenFunc const &in, TaskFunc const & t
         auto k = in();
         queue.push( k ) ;
         if( !k ) {
-            for( int i = 1; i < p.num_threads; i++ ) {
+            for( int i = 1; i < p.get_num_threads(); i++ ) {
                 queue.push( k ) ;
             }
             break;
@@ -86,9 +86,9 @@ template <typename GenFunc, typename TaskFunc>
 inline void farm(parallel_execution_tbb p, GenFunc const &in, TaskFunc const & taskf ) {
 
     tbb::task_group g;
-    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE, p.lockfree);
+    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE, p.is_lockfree());
     //Create threads
-    for( int i = 0; i < p.num_threads; i++ ) {
+    for( int i = 0; i < p.get_num_threads(); i++ ) {
        g.run(
           [&](){
               typename std::result_of<GenFunc()>::type item;
@@ -106,7 +106,7 @@ inline void farm(parallel_execution_tbb p, GenFunc const &in, TaskFunc const & t
         auto k = in();
         queue.push( k );
         if( !k ) {
-            for( int i = 1; i < p.num_threads; i++ ) {
+            for( int i = 1; i < p.get_num_threads(); i++ ) {
                queue.push( k );
             }
             break;

--- a/include/ppi_tbb/stencil_tbb.h
+++ b/include/ppi_tbb/stencil_tbb.h
@@ -28,17 +28,17 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 inline void stencil(parallel_execution_tbb p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
 
     int numElements = last - first;
-    int elemperthr = numElements/p.num_threads;
+    int elemperthr = numElements/p.get_num_threads();
     tbb::task_group g;
  
-    for(int i=1;i<p.num_threads;i++){
+    for(int i=1;i<p.get_num_threads();i++){
       
 
 
        g.run( [&neighbor, &taskf, first, firstOut, elemperthr, i, last, p ]() {
                 auto begin = first + (elemperthr * i);
                 auto end = first + (elemperthr * (i+1));
-                if( i == p.num_threads-1) end = last;
+                if( i == p.get_num_threads()-1) end = last;
                 auto out = firstOut + (elemperthr * i);
                 while(begin!=end){
                   auto neighbors = neighbor(begin);
@@ -68,17 +68,17 @@ template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Tas
 inline void stencil(parallel_execution_tbb p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
 
      int numElements = last - first;
-     int elemperthr = numElements/p.num_threads;
+     int elemperthr = numElements/p.get_num_threads();
      tbb::task_group g;
 
-     for(int i=1;i<p.num_threads;i++){
+     for(int i=1;i<p.get_num_threads();i++){
 
         
         g.run([&neighbor, &taskf, first, firstOut, elemperthr, i, last, p,inputs...]( )mutable{
         auto begin = first + (elemperthr * i);
         auto end = first + (elemperthr * (i+1));
 
-               if(i==p.num_threads-1) end = last;
+               if(i==p.get_num_threads()-1) end = last;
 
                auto out = firstOut + (elemperthr * i);
         

--- a/include/ppi_tbb/stream_filter_tbb.h
+++ b/include/ppi_tbb/stream_filter_tbb.h
@@ -29,11 +29,11 @@ inline void stream_filter(parallel_execution_tbb p, GenFunc const & in, FilterFu
 
     tbb::task_group g;
 
-    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > queue(DEFAULT_SIZE,p.lockfree);
-    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > outqueue(DEFAULT_SIZE, p.lockfree);
+    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > queue(DEFAULT_SIZE,p.is_lockfree());
+    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > outqueue(DEFAULT_SIZE, p.is_lockfree());
 
     //THREAD 1-(N-1) EXECUTE FILTER AND PUSH THE VALUE IF TRUE
-    for(int i=1; i< p.num_threads - 1; i++){
+    for(int i=1; i< p.get_num_threads() - 1; i++){
           g.run(
             [&](){
                std::pair< typename std::result_of<GenFunc()>::type,long > item;
@@ -64,11 +64,11 @@ inline void stream_filter(parallel_execution_tbb p, GenFunc const & in, FilterFu
            long order = 0;
            //Dequeue an element
            item = outqueue.pop();
-           while(nend != p.num_threads - 1){
+           while(nend != p.get_num_threads() - 1){
               //If is an end of stream element
               if(!item.first&&item.second==0){
                   nend++;
-                  if(nend == p.num_threads -2 ) break;
+                  if(nend == p.get_num_threads() -2 ) break;
               }
               //If there is not an end element
               else {
@@ -114,7 +114,7 @@ inline void stream_filter(parallel_execution_tbb p, GenFunc const & in, FilterFu
         queue.push(make_pair(k,order));
         order++;
         if( k.end ){
-           for(int i = 0; i< p.num_threads -2; i++){
+           for(int i = 0; i< p.get_num_threads() -2; i++){
               queue.push(make_pair(k,0));
            }
            break;

--- a/include/ppi_thr/divideandconquer_thr.h
+++ b/include/ppi_thr/divideandconquer_thr.h
@@ -93,6 +93,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 inline void divide_and_conquer(parallel_execution_thr& p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge) {
 
+    p.register_thread();
     std::atomic<int> num_threads ( p.get_num_threads() );
     
     if(num_threads.load()>0){
@@ -138,6 +139,7 @@ inline void divide_and_conquer(parallel_execution_thr& p, Input & problem, Outpu
 
         for(int i = 0; i<partials.size();i++){ // MarcoA - this is moved to the user code
            merge(partials[i], output);
+           p.deregister_thread();
         }
        }else{
         task(problem, output);
@@ -145,6 +147,7 @@ inline void divide_and_conquer(parallel_execution_thr& p, Input & problem, Outpu
     }else{
         divide_and_conquer(sequential_execution {}, problem, output, divide, task, merge);
     }
+
 }
 
 

--- a/include/ppi_thr/divideandconquer_thr.h
+++ b/include/ppi_thr/divideandconquer_thr.h
@@ -30,14 +30,14 @@ namespace grppi{
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
 inline void internal_divide_and_conquer(parallel_execution_thr &p, Input &problem, Output &output,
                                         DivFunc const &divide, TaskFunc const &task, MergeFunc const &merge,
-                                        std::atomic<int> &num_threads) {
+                                        std::atomic<int>& num_threads) {
 
    if(num_threads.load()>0){
       auto subproblems = divide(problem);
 
       if(subproblems.size()>1){
         std::vector<Output> partials(subproblems.size());
-//        num_threads -= subproblems.size();
+//        get_num_threads() -= subproblems.size();
         int division = 1;
         std::vector<std::thread> tasks;
         auto i = subproblems.begin();
@@ -93,7 +93,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 inline void divide_and_conquer(parallel_execution_thr& p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge) {
 
-    std::atomic<int> num_threads (p.num_threads);
+    std::atomic<int> num_threads ( p.get_num_threads() );
     
     if(num_threads.load()>0){
       auto subproblems = divide(problem);
@@ -116,10 +116,9 @@ inline void divide_and_conquer(parallel_execution_thr& p, Input & problem, Outpu
                     // Deregister the thread in the execution model
                     p.deregister_thread();
                   },
-                   i, division
-		       )
+                   i, division )
 	        );
-            num_threads --;
+            num_threads--;
             //END TRHEAD
         }
         for(i; i != subproblems.end(); i++){

--- a/include/ppi_thr/farm_thr.h
+++ b/include/ppi_thr/farm_thr.h
@@ -31,6 +31,7 @@ namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename SinkFunc>
 inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & taskf , SinkFunc const &sink) {
 
+    p.register_thread();
     std::vector<std::thread> tasks;
 //    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE);
 //    Queue< optional < typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(DEFAULT_SIZE);
@@ -100,6 +101,7 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
         }
     }
 
+    p.deregister_thread();
     //Join threads
     for( int i = 0; i < tasks.size(); i++ )
        tasks[ i ].join();
@@ -110,6 +112,8 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
 
 template <typename GenFunc, typename TaskFunc>
 inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & taskf ) {
+
+    p.register_thread();
 
     std::vector<std::thread> tasks;
 //    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE);
@@ -151,6 +155,8 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
     //Join threads
     for( int i = 0; i < p.get_num_threads(); i++ )
        tasks[ i ].join();
+
+    p.deregister_thread();
 }
 
 

--- a/include/ppi_thr/farm_thr.h
+++ b/include/ppi_thr/farm_thr.h
@@ -34,11 +34,11 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
     std::vector<std::thread> tasks;
 //    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE);
 //    Queue< optional < typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(DEFAULT_SIZE);
-    Queue< typename std::result_of<GenFunc()>::type > queue (DEFAULT_SIZE,p.lockfree);
-    Queue< optional < typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(DEFAULT_SIZE, p.lockfree);
+    Queue< typename std::result_of<GenFunc()>::type > queue (DEFAULT_SIZE,p.is_lockfree());
+    Queue< optional < typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(DEFAULT_SIZE, p.is_lockfree());
     std::atomic<int> nend(0);
     //Create threads
-    for( int i = 0; i < p.num_threads; i++ ) {
+    for( int i = 0; i < p.get_num_threads(); i++ ) {
         tasks.push_back(
             std::thread(
                 [&](){
@@ -56,7 +56,7 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
                     }
                     queue.push(item);
                     nend++;
-                    if(nend == p.num_threads)
+                    if(nend == p.get_num_threads())
                         queueout.push( optional< typename std::result_of<TaskFunc(typename std::result_of<GenFunc()>::type::value_type)>::type >() ) ;
 
                     // Deregister the thread in the execution model
@@ -93,7 +93,7 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
         auto k = in();
         queue.push( k );
         if( !k ) {
-/*            for( int i = 0; i < p.num_threads; i++ ) {
+/*            for( int i = 0; i < p.get_num_threads(); i++ ) {
                queue.push( k );
             }*/
             break;
@@ -113,10 +113,10 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
 
     std::vector<std::thread> tasks;
 //    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE);
-    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.lockfree);
+    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.is_lockfree());
     //Create threads
 //    std::atomic<int> nend(0);
-    for( int i = 0; i < p.num_threads; i++ ) {
+    for( int i = 0; i < p.get_num_threads(); i++ ) {
         tasks.push_back(
             std::thread(
                 [&](){
@@ -141,7 +141,7 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
         auto k = in();
         queue.push( k ) ;
         if( !k ) {
-/*            for( int i = 0; i < p.num_threads; i++ ) {
+/*            for( int i = 0; i < p.get_num_threads(); i++ ) {
                 queue.push( k ) ;
             }*/
             break;
@@ -149,7 +149,7 @@ inline void farm(parallel_execution_thr &p, GenFunc const &in, TaskFunc const & 
     }
 
     //Join threads
-    for( int i = 0; i < p.num_threads; i++ )
+    for( int i = 0; i < p.get_num_threads(); i++ )
        tasks[ i ].join();
 }
 

--- a/include/ppi_thr/map_thr.h
+++ b/include/ppi_thr/map_thr.h
@@ -24,6 +24,7 @@ using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc>
 inline void map(parallel_execution_thr& p, GenFunc const &in, TaskFunc const & taskf){
+   p.register_thread();
    std::vector<std::thread> tasks;
    //Create a queue per thread
   std::vector<shared_ptr<Queue<typename std::result_of<GenFunc()>::type >>> queues;
@@ -62,6 +63,7 @@ inline void map(parallel_execution_thr& p, GenFunc const &in, TaskFunc const & t
        rr++;
        rr = (rr < p.get_num_threads()-1) ? rr : 0; 
    }
+   p.deregister_thread();
    //Join threads
    for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
@@ -71,6 +73,8 @@ inline void map(parallel_execution_thr& p, GenFunc const &in, TaskFunc const & t
 template <typename InputIt, typename OutputIt, typename TaskFunc>
 inline void map(parallel_execution_thr& p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc const & taskf){
    
+   p.register_thread();
+
    std::vector<std::thread> tasks;
    int numElements = last - first; 
    int elemperthr = numElements/p.get_num_threads(); 
@@ -106,6 +110,7 @@ inline void map(parallel_execution_thr& p, InputIt first,InputIt last, OutputIt 
          first++;
          firstOut++;
    }
+   p.deregister_thread();
 
    //Join threads
    for(int i=0;i<p.get_num_threads()-1;i++){

--- a/include/ppi_thr/map_thr.h
+++ b/include/ppi_thr/map_thr.h
@@ -27,10 +27,10 @@ inline void map(parallel_execution_thr& p, GenFunc const &in, TaskFunc const & t
    std::vector<std::thread> tasks;
    //Create a queue per thread
   std::vector<shared_ptr<Queue<typename std::result_of<GenFunc()>::type >>> queues;
-  for(int i =0; i<p.num_threads-1; i++) queues.push_back( shared_ptr<Queue<typename std::result_of<GenFunc()>::type >>(new Queue<typename std::result_of<GenFunc()>::type >(DEFAULT_SIZE,p.lockfree) ) );
+  for(int i =0; i<p.get_num_threads()-1; i++) queues.push_back( shared_ptr<Queue<typename std::result_of<GenFunc()>::type >>(new Queue<typename std::result_of<GenFunc()>::type >(DEFAULT_SIZE,p.is_lockfree()) ) );
 
    //Create threads
-   for(int i=1;i<p.num_threads;i++){
+   for(int i=1;i<p.get_num_threads();i++){
       tasks.push_back(
          std::thread( [&](int tid){
             // Register the thread in the execution model
@@ -52,7 +52,7 @@ inline void map(parallel_execution_thr& p, GenFunc const &in, TaskFunc const & t
        int rr = 0;
        auto k = in();
        if(!k){
-           for(int i=0;i<p.num_threads-1;i++){
+           for(int i=0;i<p.get_num_threads()-1;i++){
                (*queues[i]).push(k);
            }
            break;
@@ -60,10 +60,10 @@ inline void map(parallel_execution_thr& p, GenFunc const &in, TaskFunc const & t
       
        (*queues[rr]).push(k);
        rr++;
-       rr = (rr < p.num_threads-1) ? rr : 0; 
+       rr = (rr < p.get_num_threads()-1) ? rr : 0; 
    }
    //Join threads
-   for(int i=0;i<p.num_threads-1;i++){
+   for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
    }
 }
@@ -73,13 +73,13 @@ inline void map(parallel_execution_thr& p, InputIt first,InputIt last, OutputIt 
    
    std::vector<std::thread> tasks;
    int numElements = last - first; 
-   int elemperthr = numElements/p.num_threads; 
+   int elemperthr = numElements/p.get_num_threads(); 
 
-   for(int i=1;i<p.num_threads;i++){
+   for(int i=1;i<p.get_num_threads();i++){
       auto begin = first + (elemperthr * i); 
       auto end = first + (elemperthr * (i+1)); 
 
-      if(i == p.num_threads -1 ) end= last;
+      if(i == p.get_num_threads() -1 ) end= last;
 
       auto out = firstOut + (elemperthr * i);
       tasks.push_back(
@@ -108,7 +108,7 @@ inline void map(parallel_execution_thr& p, InputIt first,InputIt last, OutputIt 
    }
 
    //Join threads
-   for(int i=0;i<p.num_threads-1;i++){
+   for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
    }
 
@@ -123,13 +123,13 @@ inline void map(parallel_execution_thr& p, InputIt first, InputIt last, OutputIt
  std::vector<std::thread> tasks;
    //Calculate number of elements per thread
    int numElements = last - first;
-   int elemperthr = numElements/p.num_threads;
+   int elemperthr = numElements/p.get_num_threads();
    //Create tasks
-   for(int i=1;i<p.num_threads;i++){
+   for(int i=1;i<p.get_num_threads();i++){
       //Calculate local input and output iterator 
       auto begin = first + (elemperthr * i);
       auto end = first + (elemperthr * (i+1));
-      if( i == p.num_threads-1) end = last;
+      if( i == p.get_num_threads()-1) end = last;
       auto out = firstOut + (elemperthr * i);
       //Begin task
       tasks.push_back(
@@ -164,7 +164,7 @@ inline void map(parallel_execution_thr& p, InputIt first, InputIt last, OutputIt
 
 
    //Join threads
-   for(int i=0;i<p.num_threads-1;i++){
+   for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
    }
 }

--- a/include/ppi_thr/mapreduce_thr.h
+++ b/include/ppi_thr/mapreduce_thr.h
@@ -42,15 +42,15 @@ inline void map_reduce (parallel_execution_thr & p, InputIt first, InputIt last,
 template <typename InputIt, typename MapFunc, class T, typename ReduceOperator>
 inline T map_reduce ( parallel_execution_thr& p, InputIt first, InputIt last, MapFunc const &  map, T init, ReduceOperator op){
     T out = init;
-    std::vector<T> partialOuts(p.num_threads);
+    std::vector<T> partialOuts(p.get_num_threads());
     std::vector<std::thread> tasks;
     int numElements = last - first;
-    int elemperthr = numElements/p.num_threads;
+    int elemperthr = numElements/p.get_num_threads();
 
-    for(int i=1;i<p.num_threads;i++){    
+    for(int i=1;i<p.get_num_threads();i++){    
        auto begin = first + (elemperthr * i);
        auto end = first + (elemperthr * (i+1));
-       if(i == p.num_threads -1 ) end= last;
+       if(i == p.get_num_threads() -1 ) end= last;
        tasks.push_back(
         std::thread( 
          [&](InputIt begin, InputIt end, T out){

--- a/include/ppi_thr/mapreduce_thr.h
+++ b/include/ppi_thr/mapreduce_thr.h
@@ -41,6 +41,9 @@ inline void map_reduce (parallel_execution_thr & p, InputIt first, InputIt last,
 
 template <typename InputIt, typename MapFunc, class T, typename ReduceOperator>
 inline T map_reduce ( parallel_execution_thr& p, InputIt first, InputIt last, MapFunc const &  map, T init, ReduceOperator op){
+
+    p.register_thread();
+
     T out = init;
     std::vector<T> partialOuts(p.get_num_threads());
     std::vector<std::thread> tasks;
@@ -70,6 +73,8 @@ inline T map_reduce ( parallel_execution_thr& p, InputIt first, InputIt last, Ma
        (*task).join();
     }
     Reduce(sequential_execution{}, partialOuts.begin(), partialOuts.end(), out, op);
+
+    p.deregister_thread();
 
     return out;
 }

--- a/include/ppi_thr/reduce_thr.h
+++ b/include/ppi_thr/reduce_thr.h
@@ -36,18 +36,18 @@ reduce(parallel_execution_thr& p, InputIt first, InputIt last, Output & firstOut
 
     std::vector<std::thread> tasks;
     int numElements = last - first;
-    int elemperthr = numElements/p.num_threads;
+    int elemperthr = numElements/p.get_num_threads();
     std::atomic<int> finishedTask(1); 
     //local output
-    std::vector<Output> out(p.num_threads);
+    std::vector<Output> out(p.get_num_threads());
     //Create threads
-    for(int i=1;i<p.num_threads;i++){
+    for(int i=1;i<p.get_num_threads();i++){
       
       auto begin = first + (elemperthr * i);
       auto end = first + (elemperthr * (i+1));
-      if(i == p.num_threads -1) end = last;
+      if(i == p.get_num_threads() -1) end = last;
 
-      p.pool.create_task(boost::bind<void>(
+      p.create_task(boost::bind<void>(
            [&](InputIt begin, InputIt end, int tid){
                out[tid] = identityVal;
 //               begin++;
@@ -85,10 +85,10 @@ reduce(parallel_execution_thr& p, InputIt first, InputIt last, Output & firstOut
          out[0] = op( out[0], *first);
          first++;
     }
-    while(finishedTask.load()!=p.num_threads);//{std::cout<<finishedTask.load()<<" "<<p.num_threads<<std::endl; }
+    while(finishedTask.load()!=p.get_num_threads());//{std::cout<<finishedTask.load()<<" "<<p.get_num_threads()<<std::endl; }
 
     //Join threads
-   /* for(int i=0;i<p.num_threads-1;i++){
+   /* for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
     }*/
   
@@ -106,17 +106,17 @@ Reduce(parallel_execution_thr p, InputIt first, InputIt last, Output & firstOut,
 
     std::vector<std::thread> tasks;
     int numElements = last - first;
-    int elemperthr = numElements/p.num_threads;
+    int elemperthr = numElements/p.get_num_threads();
 
     //local output
-    std::vector<Output> out(p.num_threads);
+    std::vector<Output> out(p.get_num_threads());
     int i;
     //Create threads
-    for(i=1;i<p.num_threads;i++){
+    for(i=1;i<p.get_num_threads();i++){
 
       auto begin = first + (elemperthr * i);
       auto end = first + (elemperthr * (i+1));
-      if(i == p.num_threads -1) end = last;
+      if(i == p.get_num_threads() -1) end = last;
 
       tasks.push_back(
          std::thread( [&](InputIt begin, InputIt end, int tid){
@@ -140,7 +140,7 @@ Reduce(parallel_execution_thr p, InputIt first, InputIt last, Output & firstOut,
     }
 
     //Join threads
-    for(int i=0;i<p.num_threads-1;i++){
+    for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
     }
 
@@ -174,17 +174,17 @@ reduce(parallel_execution_thr &p, InputIt first, InputIt last, ReduceOperator op
 
 //    std::vector<std::thread> tasks;
     int numElements = last - first;
-    int elemperthr = numElements/p.num_threads;
+    int elemperthr = numElements/p.get_num_threads();
     std::atomic<int> finishedTask(1);
     //local output
-    std::vector<typename ReduceOperator::result_type> out(p.num_threads);
+    std::vector<typename ReduceOperator::result_type> out(p.get_num_threads());
     //Create threads
-    for(int i=1;i<p.num_threads;i++){
+    for(int i=1;i<p.get_num_threads();i++){
 
       auto begin = first + (elemperthr * i);
       auto end = first + (elemperthr * (i+1));
-      if(i == p.num_threads -1) end = last;
-      p.pool.create_task(boost::bind<void>(
+      if(i == p.get_num_threads() -1) end = last;
+      p.create_task(boost::bind<void>(
            [&](InputIt begin, InputIt end, int tid){
                out[tid] = identityVal;
     //           begin++;
@@ -220,10 +220,10 @@ reduce(parallel_execution_thr &p, InputIt first, InputIt last, ReduceOperator op
     }
 
     //Join threads
-  //  for(int i=0;i<p.num_threads-1;i++){
+  //  for(int i=0;i<p.get_num_threads()-1;i++){
   //    tasks[i].join();
   //  }
-    while(finishedTask.load()!=p.num_threads);//{std::cout<<finishedTask.load()<<" "<<p.num_threads<<std::endl; }
+    while(finishedTask.load()!=p.get_num_threads());//{std::cout<<finishedTask.load()<<" "<<p.get_num_threads()<<std::endl; }
     
     typename ReduceOperator::result_type outVal = out[0];
     for(unsigned int i = 1; i < out.size(); i++){

--- a/include/ppi_thr/reduce_thr.h
+++ b/include/ppi_thr/reduce_thr.h
@@ -31,6 +31,7 @@ template < typename InputIt, typename Output, typename ReduceOperator>
 inline typename std::enable_if<!is_iterator<Output>::value, void>::type 
 reduce(parallel_execution_thr& p, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
 
+    p.register_thread();
     typename ReduceOperator::result_type identityVal = !op(false,true);
 
 
@@ -49,6 +50,7 @@ reduce(parallel_execution_thr& p, InputIt first, InputIt last, Output & firstOut
 
       p.create_task(boost::bind<void>(
            [&](InputIt begin, InputIt end, int tid){
+               p.register_thread();
                out[tid] = identityVal;
 //               begin++;
                
@@ -57,6 +59,7 @@ reduce(parallel_execution_thr& p, InputIt first, InputIt last, Output & firstOut
                    //begin++;
                }
                finishedTask++;
+               p.deregister_thread();
             },
             std::move(begin), std::move(end), i
       ));
@@ -97,6 +100,7 @@ reduce(parallel_execution_thr& p, InputIt first, InputIt last, Output & firstOut
        firstOut = op( firstOut, *it);
        it++;
     }
+    p.deregister_thread();
 }
 
 /*

--- a/include/ppi_thr/stencil_thr.h
+++ b/include/ppi_thr/stencil_thr.h
@@ -26,6 +26,7 @@ namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
 inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
 
+    p.register_thread();
     std::vector<std::thread> tasks;
     int numElements = last - first;
     int elemperthr = numElements/p.get_num_threads();
@@ -64,7 +65,7 @@ inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, Outp
       first++;
       firstOut++;
    }
-
+   p.deregister_thread();
    //Join threads
    for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
@@ -75,6 +76,7 @@ inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, Outp
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc, typename NFunc>
 inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
 
+     p.register_thread();
      std::vector<std::thread> tasks;
      int numElements = last - first;
      int elemperthr = numElements/p.get_num_threads();
@@ -119,6 +121,7 @@ inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, Outp
       NextInputs( inputs ... );
       firstOut++;
    }
+   p.deregister_thread();
 
 
    //Join threads

--- a/include/ppi_thr/stencil_thr.h
+++ b/include/ppi_thr/stencil_thr.h
@@ -28,13 +28,13 @@ inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, Outp
 
     std::vector<std::thread> tasks;
     int numElements = last - first;
-    int elemperthr = numElements/p.num_threads;
+    int elemperthr = numElements/p.get_num_threads();
  
-    for(int i=1;i<p.num_threads;i++){
+    for(int i=1;i<p.get_num_threads();i++){
        auto begin = first + (elemperthr * i);
        auto end = first + (elemperthr * (i+1));
       
-       if( i == p.num_threads-1) end = last;
+       if( i == p.get_num_threads()-1) end = last;
 
        auto out = firstOut + (elemperthr * i);
 
@@ -66,7 +66,7 @@ inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, Outp
    }
 
    //Join threads
-   for(int i=0;i<p.num_threads-1;i++){
+   for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
    }
  
@@ -77,14 +77,14 @@ inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, Outp
 
      std::vector<std::thread> tasks;
      int numElements = last - first;
-     int elemperthr = numElements/p.num_threads;
+     int elemperthr = numElements/p.get_num_threads();
 
-     for(int i=1;i<p.num_threads;i++){
+     for(int i=1;i<p.get_num_threads();i++){
 
         auto begin = first + (elemperthr * i);
         auto end = first + (elemperthr * (i+1));
 
-	if(i==p.num_threads-1) end = last;
+	if(i==p.get_num_threads()-1) end = last;
 
         auto out = firstOut + (elemperthr * i);
         
@@ -122,7 +122,7 @@ inline void stencil(parallel_execution_thr &p, InputIt first, InputIt last, Outp
 
 
    //Join threads
-   for(int i=0;i<p.num_threads-1;i++){
+   for(int i=0;i<p.get_num_threads()-1;i++){
       tasks[i].join();
    }
 

--- a/include/ppi_thr/stream_filter_thr.h
+++ b/include/ppi_thr/stream_filter_thr.h
@@ -26,6 +26,7 @@ namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
 inline void stream_filter(parallel_execution_thr &p, GenFunc const & in, FilterFunc const & filter, OutFunc const & out ) {
 
+    p.register_thread();
     std::vector<std::thread> tasks;
 
     Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > queue(DEFAULT_SIZE,p.is_lockfree());
@@ -136,6 +137,7 @@ inline void stream_filter(parallel_execution_thr &p, GenFunc const & in, FilterF
            break;
         }
     }
+    p.deregister_thread();
 
     for(int i = 0; i< p.get_num_threads(); i++) tasks[i].join();
 

--- a/include/ppi_thr/stream_filter_thr.h
+++ b/include/ppi_thr/stream_filter_thr.h
@@ -28,11 +28,11 @@ inline void stream_filter(parallel_execution_thr &p, GenFunc const & in, FilterF
 
     std::vector<std::thread> tasks;
 
-    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > queue(DEFAULT_SIZE,p.lockfree);
-    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > outqueue(DEFAULT_SIZE,p.lockfree);
+    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > queue(DEFAULT_SIZE,p.is_lockfree());
+    Queue< std::pair< typename std::result_of<GenFunc()>::type, long> > outqueue(DEFAULT_SIZE,p.is_lockfree());
 
     //THREAD 1-(N-1) EXECUTE FILTER AND PUSH THE VALUE IF TRUE
-    for(int i=0; i< p.num_threads - 1; i++){
+    for(int i=0; i< p.get_num_threads() - 1; i++){
       tasks.push_back(
           std::thread(
             [&](){
@@ -77,11 +77,11 @@ inline void stream_filter(parallel_execution_thr &p, GenFunc const & in, FilterF
            long order = 0;
            //Dequeue an element
            item = outqueue.pop();
-           while(nend != p.num_threads - 1){
+           while(nend != p.get_num_threads() - 1){
               //If is an end of stream element
               if(!item.first&&item.second==0){
                   nend++;
-                  if(nend == p.num_threads -1 ) break;
+                  if(nend == p.get_num_threads() -1 ) break;
               }
               //If there is not an end element
               else {
@@ -130,14 +130,14 @@ inline void stream_filter(parallel_execution_thr &p, GenFunc const & in, FilterF
         queue.push(make_pair(k,order));
         order++;
         if( k.end ){
-           for(int i = 0; i< p.num_threads -1; i++){
+           for(int i = 0; i< p.get_num_threads() -1; i++){
               queue.push(make_pair(k,0));
            }
            break;
         }
     }
 
-    for(int i = 0; i< p.num_threads; i++) tasks[i].join();
+    for(int i = 0; i< p.get_num_threads(); i++) tasks[i].join();
 
 }
 

--- a/include/ppi_thr/stream_iteration_thr.h
+++ b/include/ppi_thr/stream_iteration_thr.h
@@ -56,6 +56,7 @@ inline void stream_iteration(parallel_execution_thr &p, GenFunc const & in, Pipe
    composed_pipeline< Queue< typename std::result_of<GenFunc()>::type >, Queue< typename std::result_of<GenFunc()>::type >, 0, Stages ...>
       (queue, se, queueOut, pipeThreads); 
  
+   p.register_thread();
    while(1){
       //If every element has been processed
       if(sendFinish&&nelem==0){
@@ -72,6 +73,7 @@ inline void stream_iteration(parallel_execution_thr &p, GenFunc const & in, Pipe
       }else queue.push( k );
 
    }
+   p.deregister_thread();
    auto first = pipeThreads.begin();
    auto end = pipeThreads.end();
    gen.join();
@@ -140,6 +142,7 @@ inline void stream_iteration(parallel_execution_thr &p, GenFunc const & in, Farm
           }
       ));
    }
+   se->register_thread();
    //Output function
    std::thread outth([&](){
       while(1){
@@ -148,6 +151,7 @@ inline void stream_iteration(parallel_execution_thr &p, GenFunc const & in, Farm
          out(k.value());
       }
    });
+   se->deregister_thread();
    //Join threads
    auto first = tasks.begin();
    auto end = tasks.end();

--- a/include/ppi_thr/stream_iteration_thr.h
+++ b/include/ppi_thr/stream_iteration_thr.h
@@ -142,7 +142,7 @@ inline void stream_iteration(parallel_execution_thr &p, GenFunc const & in, Farm
           }
       ));
    }
-   se->register_thread();
+   se.exectype->register_thread();
    //Output function
    std::thread outth([&](){
       while(1){
@@ -151,7 +151,7 @@ inline void stream_iteration(parallel_execution_thr &p, GenFunc const & in, Farm
          out(k.value());
       }
    });
-   se->deregister_thread();
+   se.exectype->deregister_thread();
    //Join threads
    auto first = tasks.begin();
    auto end = tasks.end();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,6 @@ set( TESTS_CPU_THR
      divideandconquer-fibonacci stream_reduce_new
      stream_iteration1
      stream_iteration_pipe
-     affinity_test
 # Examples in the Deliverable
      pipeline_example       farm_example           filter_example
      stream_reduce_example  pipeline+filter_test_ppi_example

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ set( TESTS_CPU_THR
      divideandconquer-fibonacci stream_reduce_new
      stream_iteration1
      stream_iteration_pipe
+     affinity_test
 # Examples in the Deliverable
      pipeline_example       farm_example           filter_example
      stream_reduce_example  pipeline+filter_test_ppi_example
@@ -80,10 +81,13 @@ foreach( m ${EXE_LIB} )
    foreach( t ${TESTS_CPU_${m}} )
 
       add_executable( ${t}_${m} ${t}.cpp )
-      
+       
       set_target_properties(${t}_${m} PROPERTIES COMPILE_FLAGS "-D${m}" )
       if ( ${m} STREQUAL THR )
          target_link_libraries( ${t}_${m} pthread )
+         if(HWLOC_FOUND)
+             target_link_libraries( ${t}_${m} hwloc)
+         endif()
       elseif ( ${m} STREQUAL TBB )
          target_link_libraries( ${t}_${m} tbb )
       endif()

--- a/tests/affinity_test.cpp
+++ b/tests/affinity_test.cpp
@@ -1,0 +1,86 @@
+/**
+* @version		GrPPI v0.1
+* @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
+* @license		GNU/GPL, see LICENSE.txt
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You have received a copy of the GNU General Public License in LICENSE.txt
+* also available in <http://www.gnu.org/licenses/gpl.html>.
+*
+* See COPYRIGHT.txt for copyright notices and details.
+*/
+#include <iostream>
+#include <vector>
+#include <fstream>
+#include <chrono>
+#include <farm.h>
+
+using namespace std;
+using namespace grppi;
+
+void farm_example1() {
+
+#ifndef NTHREADS
+#define NTHREADS 4
+#endif
+
+#if THR
+    parallel_execution_thr p{NTHREADS};
+#else
+   #error Affinity is only supported for C++ thread implementation in the current version
+#endif
+
+    
+    int a = 200000;
+    //Thread binding
+    for ( int i =0;i<NTHREADS; i++){
+       //Bind each thread to the CPU core with the same number as the Thread ID.
+       p.set_thread_affinity(i, {i});
+    }
+    //Numa binding
+    for(int i = 0; i< NTHREADS; i++){
+       //Bind thread alternatively to the numa nodes 1 and 2. If there only one numa node, this has no effects.
+       p.set_numa_affinity(i, {i%2});
+    }
+    
+    farm(p,
+        // farm generator as lambda
+        [&]() {
+            //Thread 0 - Core 0 - NUMA 0
+            a--; 
+            if ( a == 0 ) 
+                return optional<int>(); 
+            else
+                return optional<int>( a );
+        },
+
+        // farm kernel as lambda
+        [&]( int l ) {
+            //Thread 1 - Core 1 - NUMA 1
+            //Thread 2 - Core 2 - NUMA 0
+            //Thread 3 - Core 3 - NUMA 1
+           //The memory allocation is done in both numa nodes and only cores 0-4 are active.
+           std::vector<double> memtest(l,1);
+           for(int i=0;i<memtest.size();i++) { memtest[i] += 1; }
+        }
+    );
+}
+
+int main() {
+
+    //$ auto start = std::chrono::high_resolution_clock::now();
+    farm_example1();
+    //$ auto elapsed = std::chrono::high_resolution_clock::now() - start;
+
+    //$ long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>( elapsed ).count();
+    //$ std::cout << "Execution time : " << microseconds << " us" << std::endl;
+    return 0;
+}

--- a/tests/pipeline+farm.cpp
+++ b/tests/pipeline+farm.cpp
@@ -48,7 +48,7 @@ void pipeline_farm_example() {
 
     int n=10;
     std::vector<string> output;
-    p.ordering=true;
+    p.set_ordered(true);
 
     pipeline(p,
              // Pipeline stage 0

--- a/tests/pipeline+filter_test_ppi_example.cpp
+++ b/tests/pipeline+filter_test_ppi_example.cpp
@@ -45,7 +45,7 @@ void pipeline_example1() {
 #endif
 
     int a = 10;
-p.ordering=true;
+p.set_ordered(true);
 
     pipeline( p,
         // Pipeline stage 0

--- a/tests/pipeline1.cpp
+++ b/tests/pipeline1.cpp
@@ -45,7 +45,7 @@ void pipeline_example1() {
 #endif
     int a = 10;
     std::vector<string> output;
-    p.ordering=true;
+    p.set_ordered(true);
     pipeline( p,
         // Pipeline stage 0
         [&]() { 

--- a/tests/pipeline2.cpp
+++ b/tests/pipeline2.cpp
@@ -46,7 +46,7 @@ void pipeline_example2() {
 #endif
 
     std::vector<string> output;
-    p.ordering=true;
+    p.set_ordered(true);
     ifstream fe("txt/words.txt");
     if (!fe.good()) return;
     int numchar = 0;

--- a/tests/pipeline4.cpp
+++ b/tests/pipeline4.cpp
@@ -45,7 +45,7 @@ void pipeline_example1() {
 #endif
 
     int a = 10;
-    p.ordering=true;
+    p.set_ordered(true);
     /* Test exit inmediately in the first stage */
     pipeline( p,
         // Pipeline stage 0

--- a/tests/pipeline_example.cpp
+++ b/tests/pipeline_example.cpp
@@ -63,7 +63,7 @@ void pipeline_example() {
     ifstream is("txt/file.txt");
     if (!is.good()) { cerr << "TXT file not found!" << endl; return; }
     int numchar = 0;
-    p.ordering=true;
+    p.set_ordered(true);
     pipeline( p,
         // Pipeline stage 0
         [&]() {


### PR DESCRIPTION
Changes:
- Execution policies have been modified. Data members are now private and the functions to access them have been implemented.
- Acceses to policies data members in the patterns implementations have been modified acording to the previous change.
- The paralle_execution_thr have been improved by supporting "thread pinning" and "memory binding". These features requires the hwloc library and to enable them the compilation requires the flag "-DGRPPI_HWLOC".
- The "FindHWLOC" CMake module have been added to check if hwloc library is installed in the system.
- A new test have been implemented to check the functionality of the thread/memory binding feature.