### PR TITLE
Add support for GoogleTest under clang++

### DIFF
--- a/legacy_utest/CMakeLists.txt
+++ b/legacy_utest/CMakeLists.txt
@@ -3,7 +3,9 @@ include_directories( ${PROJECT_SOURCE_DIR} )
 
 file(COPY ${CMAKE_SOURCE_DIR}/legacy_utest/txt DESTINATION "${CMAKE_BINARY_DIR}/legacy_utest/")
 
-# Required for new cmake versions
+# Set policy to support newer version of CMake and GTest
+# We will remove this when minimum version of CMake for GrPPI is move to 3.3 or
+# higher
 if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()

--- a/legacy_utest/CMakeLists.txt
+++ b/legacy_utest/CMakeLists.txt
@@ -11,8 +11,10 @@ endif()
 find_package(GTest REQUIRED) 
 include_directories(${GTEST_INCLUDE_DIRS})
 
-# Add coverage options
-add_compile_options(--coverage)
+if ( NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") )
+  # Add coverage options
+  add_compile_options(--coverage)
+endif()
 
 set(NEW_TESTS_CPU 
     divideandconquer1     divideandconquer-fibonacci    farm1 

--- a/legacy_utest/CMakeLists.txt
+++ b/legacy_utest/CMakeLists.txt
@@ -3,6 +3,12 @@ include_directories( ${PROJECT_SOURCE_DIR} )
 
 file(COPY ${CMAKE_SOURCE_DIR}/legacy_utest/txt DESTINATION "${CMAKE_BINARY_DIR}/legacy_utest/")
 
+# Required for new cmake versions
+if(POLICY CMP0057)
+  cmake_policy(SET CMP0057 NEW)
+endif()
+
+find_package(GTest REQUIRED) 
 include_directories(${GTEST_INCLUDE_DIRS})
 
 # Add coverage options

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -3,7 +3,9 @@ option(GRPPI_UNIT_TEST_ENABLE "Activate unit tests" OFF)
 
 if(GRPPI_UNIT_TEST_ENABLE)
   
-  # Required for new cmake versions
+  # Set policy to support newer version of CMake and GTest
+  # We will remove this when minimum version of CMake for GrPPI is move to 3.3 or
+  # higher
   if(POLICY CMP0057)
     cmake_policy(SET CMP0057 NEW)
   endif()

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -2,20 +2,27 @@
 option(GRPPI_UNIT_TEST_ENABLE "Activate unit tests" OFF)
 
 if(GRPPI_UNIT_TEST_ENABLE)
+  
+  # Required for new cmake versions
+  if(POLICY CMP0057)
+    cmake_policy(SET CMP0057 NEW)
+  endif()
 
+  find_package(GTest REQUIRED) 
   include_directories(${GTEST_INCLUDE_DIRS})
 
   # Unit testing should be made in debug mode
   set(CMAKE_BUILD_TYPE "Debug")
 
-  # Add coverage options
-  add_compile_options(--coverage)
+  if ( NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") )
+    # Add coverage options
+    add_compile_options(--coverage)
+  endif()
 
   set(PROJECT_TEST_NAME utest_${PROJECT_NAME_STR})
   file(GLOB TEST_SRC_FILES
        ${CMAKE_CURRENT_SOURCE_DIR}/*cpp)
 
-  find_package(GTest REQUIRED) 
   add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
   target_link_libraries(${PROJECT_TEST_NAME} 
       ${GTEST_BOTH_LIBRARIES} 
@@ -24,22 +31,26 @@ if(GRPPI_UNIT_TEST_ENABLE)
       ${CMAKE_THREAD_LIBS_INIT}
       ${Boost_LIBRARIES}
   )
+  
   GTEST_ADD_TESTS(${PROJECT_TEST_NAME} "" ${TEST_SRC_FILES})
 
-  # # Coverage options
-  find_program(LCOV_CMD lcov)
-  find_program(GENHTML_CMD genhtml)
+  # Coverage options
+  if ( NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") )
 
-  ADD_CUSTOM_TARGET(coverage
-      ${LCOV_CMD} --directory . --zerocounters
-      COMMAND ${PROJECT_TEST_NAME}
-      COMMAND ${LCOV_CMD} --directory . --capture --output-file mycov.info
-      COMMAND ${LCOV_CMD} --remove mycov.info '/usr/*' 'unit_tests/*' 
-            --output-file mycov.info.cleaned
-      COMMAND ${GENHTML_CMD} -o mycov mycov.info.cleaned --legend -s 
-      COMMAND ${CMAKE_COMMAND} -E remove mycov.info mycov.info.cleaned
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      COMMENT "Computing coverage and generating report"
-  )
+    find_program(LCOV_CMD lcov)
+    find_program(GENHTML_CMD genhtml)
+
+    ADD_CUSTOM_TARGET(coverage
+        ${LCOV_CMD} --directory . --zerocounters
+        COMMAND ${PROJECT_TEST_NAME}
+        COMMAND ${LCOV_CMD} --directory . --capture --output-file mycov.info
+        COMMAND ${LCOV_CMD} --remove mycov.info '/usr/*' 'unit_tests/*' 
+              --output-file mycov.info.cleaned
+        COMMAND ${GENHTML_CMD} -o mycov mycov.info.cleaned --legend -s 
+        COMMAND ${CMAKE_COMMAND} -E remove mycov.info mycov.info.cleaned
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Computing coverage and generating report"
+    )
+  endif()
 
 endif(GRPPI_UNIT_TEST_ENABLE)


### PR DESCRIPTION
Introduced condition to disable coverage on clang. 
Introduced policy CMP0057 check, it gives error if not set in cmake 3.9