### PR TITLE
Execution policies by const& - Issue 58

### DIFF
--- a/include/ppi_omp/divideandconquer_omp.h
+++ b/include/ppi_omp/divideandconquer_omp.h
@@ -28,7 +28,7 @@ namespace grppi
 {
 using namespace std;
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void internal_divide_and_conquer(parallel_execution_omp p, Input & problem, Output & output,
+ void internal_divide_and_conquer(parallel_execution_omp const & p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge, std::atomic<int> & num_threads) {
     
    
@@ -74,7 +74,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 }
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void divide_and_conquer(parallel_execution_omp p, Input & problem, Output & output,
+ void divide_and_conquer(parallel_execution_omp const & p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge) {
     std::atomic<int> num_threads( p.num_threads );
 

--- a/include/ppi_omp/divideandconquer_omp.h
+++ b/include/ppi_omp/divideandconquer_omp.h
@@ -28,7 +28,7 @@ namespace grppi
 {
 using namespace std;
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void internal_divide_and_conquer(parallel_execution_omp const &p, Input & problem, Output & output,
+ void internal_divide_and_conquer(parallel_execution_omp &p, Input & problem, Output & output,
             DivFunc && divide, TaskFunc && task, MergeFunc && merge, std::atomic<int> & num_threads) {
    
     if(num_threads.load()>0){
@@ -73,7 +73,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 }
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void divide_and_conquer(parallel_execution_omp const &p, Input & problem, Output & output,
+ void divide_and_conquer(parallel_execution_omp &p, Input & problem, Output & output,
             DivFunc && divide, TaskFunc && task, MergeFunc && merge) {
 
     std::atomic<int> num_threads( p.num_threads );

--- a/include/ppi_omp/farm_omp.h
+++ b/include/ppi_omp/farm_omp.h
@@ -28,7 +28,7 @@ namespace grppi
 using namespace std;
 
 template <typename GenFunc, typename TaskFunc>
-void farm(parallel_execution_omp p, GenFunc const &in, TaskFunc const &taskf) {
+void farm(parallel_execution_omp const &p, GenFunc const &in, TaskFunc const &taskf) {
 	
     Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.lockfree);
     #pragma omp parallel

--- a/include/ppi_omp/farm_omp.h
+++ b/include/ppi_omp/farm_omp.h
@@ -28,7 +28,7 @@ namespace grppi
 using namespace std;
 
 template <typename GenFunc, typename TaskFunc>
-void farm(parallel_execution_omp const &p, GenFunc &&in, TaskFunc &&taskf) {
+void farm(parallel_execution_omp &p, GenFunc &&in, TaskFunc &&taskf) {
 	
     Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.lockfree);
     #pragma omp parallel
@@ -65,7 +65,7 @@ void farm(parallel_execution_omp const &p, GenFunc &&in, TaskFunc &&taskf) {
 }
 
 template <typename TaskFunc>
-FarmObj<parallel_execution_omp,TaskFunc> farm(parallel_execution_omp p, TaskFunc && taskf){
+FarmObj<parallel_execution_omp,TaskFunc> farm(parallel_execution_omp &p, TaskFunc && taskf){
    return FarmObj<parallel_execution_omp, TaskFunc>(p,taskf);
 }
 }

--- a/include/ppi_omp/map_omp.h
+++ b/include/ppi_omp/map_omp.h
@@ -27,7 +27,7 @@ using namespace std;
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>
- void map(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc &&taskf){
+ void map(parallel_execution_omp &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc &&taskf){
    
   int numElements = last - first;
 
@@ -70,7 +70,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc>
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
- void internal_map(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut,
+ void internal_map(parallel_execution_omp &p, InputIt first, InputIt last, OutputIt firstOut,
                          TaskFunc &&taskf, int i, int elemperthr, MoreIn ... inputs){
         //Calculate local input and output iterator 
         auto begin = first + (elemperthr * i);
@@ -88,7 +88,7 @@ template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Tas
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
- void map(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, MoreIn ... inputs){
+ void map(parallel_execution_omp &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, MoreIn ... inputs){
    //Calculate number of elements per thread
    int numElements = last - first;
    int elemperthr = numElements/p.num_threads;

--- a/include/ppi_omp/map_omp.h
+++ b/include/ppi_omp/map_omp.h
@@ -27,7 +27,7 @@ using namespace std;
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>
- void map(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const &taskf){
+ void map(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const &taskf){
    
   int numElements = last - first;
 
@@ -70,7 +70,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc>
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
- void internal_map(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut,
+ void internal_map(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut,
                          TaskFunc const &taskf, int i, int elemperthr, MoreIn ... inputs){
         //Calculate local input and output iterator 
         auto begin = first + (elemperthr * i);
@@ -88,7 +88,7 @@ template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Tas
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
- void map(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs){
+ void map(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs){
    //Calculate number of elements per thread
    int numElements = last - first;
    int elemperthr = numElements/p.num_threads;

--- a/include/ppi_omp/pipeline_omp.h
+++ b/include/ppi_omp/pipeline_omp.h
@@ -29,7 +29,7 @@ using namespace std;
 namespace grppi{
 //Last stage
 template <typename Stream, typename Stage>
-void stages( parallel_execution_omp const &p, Stream& st, Stage && s ){
+void stages( parallel_execution_omp &p, Stream& st, Stage && s ){
 
     //Start task
     typename Stream::value_type item;
@@ -75,7 +75,7 @@ void stages( parallel_execution_omp const &p, Stream& st, Stage && s ){
 }
 
 template <typename Task, typename Stream,typename... Stages>
- void stages( parallel_execution_omp const &p, Stream& st, FilterObj<parallel_execution_omp, Task>& se, Stages && ... sgs ) {
+ void stages( parallel_execution_omp &p, Stream& st, FilterObj<parallel_execution_omp, Task>& se, Stages && ... sgs ) {
     if(p.ordering){
        Queue< typename Stream::value_type > q(DEFAULT_SIZE);
 
@@ -186,7 +186,7 @@ template <typename Task, typename Stream,typename... Stages>
 
 
 template <typename Task, typename Stream,typename... Stages>
- void stages( parallel_execution_omp const &p, Stream& st, FarmObj<parallel_execution_omp, Task> se, Stages && ... sgs ) {
+ void stages( parallel_execution_omp &p, Stream& st, FarmObj<parallel_execution_omp, Task> se, Stages && ... sgs ) {
    
     Queue< std::pair < optional < typename std::result_of< Task(typename Stream::value_type::first_type::value_type) >::type >, long > > q(DEFAULT_SIZE);
     std::atomic<int> nend ( 0 );
@@ -215,7 +215,7 @@ template <typename Task, typename Stream,typename... Stages>
 
 //Intermediate stages
 template <typename Stage, typename Stream,typename ... Stages>
-void stages(parallel_execution_omp const &p, Stream& st, Stage && se, Stages && ... sgs ) {
+void stages(parallel_execution_omp &p, Stream& st, Stage && se, Stages && ... sgs ) {
 
     //Create new queue
 //    boost::lockfree::spsc_queue< optional< typename std::result_of< Stage(typename Stream::value_type::value_type) > ::type>, boost::lockfree::capacity<BOOST_QUEUE_SIZE>> q;
@@ -243,7 +243,7 @@ void stages(parallel_execution_omp const &p, Stream& st, Stage && se, Stages && 
 template <typename FuncIn, typename = typename std::result_of<FuncIn()>::type,
           typename ...Stages,
           requires_no_arguments<FuncIn> = 0>
-void pipeline(parallel_execution_omp const &p, FuncIn && in, Stages && ... sts ) {
+void pipeline(parallel_execution_omp &p, FuncIn && in, Stages && ... sts ) {
 
     //Create first queue
     Queue<std::pair< typename std::result_of<FuncIn()>::type, long>> q(DEFAULT_SIZE);

--- a/include/ppi_omp/pipeline_omp.h
+++ b/include/ppi_omp/pipeline_omp.h
@@ -29,7 +29,7 @@ using namespace std;
 namespace grppi{
 //Last stage
 template <typename Stream, typename Stage>
-void stages( parallel_execution_omp p, Stream& st, Stage const& s ){
+void stages( parallel_execution_omp const &p, Stream& st, Stage const& s ){
     //Start task
     typename Stream::value_type item;
     std::vector<typename Stream::value_type> elements;
@@ -74,7 +74,7 @@ void stages( parallel_execution_omp p, Stream& st, Stage const& s ){
 }
 
 template <typename Task, typename Stream,typename... Stages>
- void stages( parallel_execution_omp p, Stream& st, FilterObj<parallel_execution_omp, Task>& se, Stages ... sgs ) {
+ void stages( parallel_execution_omp const &p, Stream& st, FilterObj<parallel_execution_omp, Task>& se, Stages ... sgs ) {
     if(p.ordering){
        Queue< typename Stream::value_type > q(DEFAULT_SIZE);
 
@@ -187,7 +187,7 @@ template <typename Task, typename Stream,typename... Stages>
 }
 
 template <typename Task, typename Stream,typename... Stages>
- void stages( parallel_execution_omp p, Stream& st, FarmObj<parallel_execution_omp, Task> se, Stages ... sgs ) {
+ void stages( parallel_execution_omp const &p, Stream& st, FarmObj<parallel_execution_omp, Task> se, Stages ... sgs ) {
    
     Queue< std::pair < optional < typename std::result_of< Task(typename Stream::value_type::first_type::value_type) >::type >, long > > q(DEFAULT_SIZE);
     std::atomic<int> nend ( 0 );
@@ -216,7 +216,7 @@ template <typename Task, typename Stream,typename... Stages>
 
 //Intermediate stages
 template <typename Stage, typename Stream,typename ... Stages>
-void stages(parallel_execution_omp p, Stream& st, Stage const& se, Stages ... sgs ) {
+void stages(parallel_execution_omp const &p, Stream& st, Stage const& se, Stages ... sgs ) {
 
     //Create new queue
 //    boost::lockfree::spsc_queue< optional< typename std::result_of< Stage(typename Stream::value_type::value_type) > ::type>, boost::lockfree::capacity<BOOST_QUEUE_SIZE>> q;
@@ -244,7 +244,7 @@ void stages(parallel_execution_omp p, Stream& st, Stage const& se, Stages ... sg
 template <typename FuncIn, typename = typename std::result_of<FuncIn()>::type,
           typename ...Stages,
           requires_no_arguments<FuncIn> = 0>
-void pipeline(parallel_execution_omp p, FuncIn const & in, Stages ... sts ) {
+void pipeline(parallel_execution_omp const &p, FuncIn const & in, Stages ... sts ) {
 
     //Create first queue
     Queue<std::pair< typename std::result_of<FuncIn()>::type, long>> q(DEFAULT_SIZE);

--- a/include/ppi_omp/reduce_omp.h
+++ b/include/ppi_omp/reduce_omp.h
@@ -31,7 +31,7 @@ namespace grppi{
 
 template < typename InputIt, typename Output, typename ReduceOperator>
  typename std::enable_if<!is_iterator<Output>::value, void>::type 
-reduce(parallel_execution_omp const &p, InputIt first, InputIt last, Output &firstOut, ReduceOperator op) {
+reduce(parallel_execution_omp &p, InputIt first, InputIt last, Output &firstOut, ReduceOperator op) {
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
     typename ReduceOperator::result_type identityVal = !op(false,true);
@@ -124,7 +124,7 @@ Reduce(parallel_execution_omp p, InputIt first, InputIt last, Output & firstOut,
 */
 template < typename InputIt, typename OutputIt, typename RedFunc>
  typename  std::enable_if<is_iterator<OutputIt>::value, void>::type
-reduce(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, RedFunc &&reduce) {
+reduce(parallel_execution_omp &p, InputIt first, InputIt last, OutputIt firstOut, RedFunc &&reduce) {
     while( first != last ) {
        reduce(*first, *firstOut);
        first++;
@@ -148,7 +148,7 @@ template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Tas
 
 template < typename InputIt, typename ReduceOperator>
  typename ReduceOperator::result_type
-reduce(parallel_execution_omp const &p, InputIt first, InputIt last, ReduceOperator op) {
+reduce(parallel_execution_omp &p, InputIt first, InputIt last, ReduceOperator op) {
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
     typename ReduceOperator::result_type identityVal = !op(false,true);

--- a/include/ppi_omp/reduce_omp.h
+++ b/include/ppi_omp/reduce_omp.h
@@ -31,7 +31,7 @@ namespace grppi{
 
 template < typename InputIt, typename Output, typename ReduceOperator>
  typename std::enable_if<!is_iterator<Output>::value, void>::type 
-reduce(parallel_execution_omp p, InputIt first, InputIt last, Output &firstOut, ReduceOperator op) {
+reduce(parallel_execution_omp const &p, InputIt first, InputIt last, Output &firstOut, ReduceOperator op) {
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
     typename ReduceOperator::result_type identityVal = !op(false,true);
@@ -124,7 +124,7 @@ Reduce(parallel_execution_omp p, InputIt first, InputIt last, Output & firstOut,
 */
 template < typename InputIt, typename OutputIt, typename RedFunc>
  typename  std::enable_if<is_iterator<OutputIt>::value, void>::type
-reduce(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, RedFunc const &reduce) {
+reduce(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, RedFunc const &reduce) {
     while( first != last ) {
        reduce(*first, *firstOut);
        first++;
@@ -148,7 +148,7 @@ template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Tas
 
 template < typename InputIt, typename ReduceOperator>
  typename ReduceOperator::result_type
-reduce(parallel_execution_omp p, InputIt first, InputIt last, ReduceOperator op) {
+reduce(parallel_execution_omp const &p, InputIt first, InputIt last, ReduceOperator op) {
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
     typename ReduceOperator::result_type identityVal = !op(false,true);

--- a/include/ppi_omp/stencil_omp.h
+++ b/include/ppi_omp/stencil_omp.h
@@ -26,7 +26,7 @@
 using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
+ void stencil(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
 
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
@@ -68,7 +68,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 }
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
+ void stencil(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
 
      int numElements = last - first;
      int elemperthr = numElements/p.num_threads;

--- a/include/ppi_omp/stencil_omp.h
+++ b/include/ppi_omp/stencil_omp.h
@@ -26,7 +26,7 @@
 using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {
+ void stencil(parallel_execution_omp &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {
 
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
@@ -68,7 +68,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 }
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_omp const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor, MoreIn ... inputs ) {
+ void stencil(parallel_execution_omp &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor, MoreIn ... inputs ) {
 
      int numElements = last - first;
      int elemperthr = numElements/p.num_threads;

--- a/include/ppi_omp/stream_filter_omp.h
+++ b/include/ppi_omp/stream_filter_omp.h
@@ -26,7 +26,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
- void stream_filter(parallel_execution_omp p, GenFunc const & in, FilterFunc const & filter, OutFunc const & out ) {
+ void stream_filter(parallel_execution_omp const &p, GenFunc const & in, FilterFunc const & filter, OutFunc const & out ) {
 
     Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE, p.lockfree);
     Queue< typename std::result_of<GenFunc()>::type > outqueue(DEFAULT_SIZE, p.lockfree);

--- a/include/ppi_omp/stream_filter_omp.h
+++ b/include/ppi_omp/stream_filter_omp.h
@@ -26,7 +26,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
- void stream_filter(parallel_execution_omp const &p, GenFunc && in, FilterFunc && filter, OutFunc && out ) {
+ void stream_filter(parallel_execution_omp &p, GenFunc && in, FilterFunc && filter, OutFunc && out ) {
 
 
     Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE, p.lockfree);
@@ -88,7 +88,7 @@ template <typename GenFunc, typename FilterFunc, typename OutFunc>
 }
 
 template <typename FilterFunc>
-FilterObj<parallel_execution_omp, FilterFunc> stream_filter(parallel_execution_omp p, FilterFunc && taskf){
+FilterObj<parallel_execution_omp, FilterFunc> stream_filter(parallel_execution_omp &p, FilterFunc && taskf){
    return FilterObj<parallel_execution_omp, FilterFunc>(p, taskf);
 
 }

--- a/include/ppi_omp/stream_reduce_omp.h
+++ b/include/ppi_omp/stream_reduce_omp.h
@@ -29,7 +29,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
- void stream_reduce(parallel_execution_omp p, GenFunc const &in, TaskFunc const & taskf, ReduceFunc const &red, OutputType &reduce_value ){
+ void stream_reduce(parallel_execution_omp const &p, GenFunc const &in, TaskFunc const & taskf, ReduceFunc const &red, OutputType &reduce_value ){
 	
     Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.lockfree);
     Queue<optional<OutputType>> end_queue(DEFAULT_SIZE, p.lockfree);
@@ -82,7 +82,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename Out
 
 
 template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
- void stream_reduce(parallel_execution_omp p, GenFunc const &in, int windowsize, int offset, ReduceOperator const & op, SinkFunc const &sink)
+ void stream_reduce(parallel_execution_omp const &p, GenFunc const &in, int windowsize, int offset, ReduceOperator const & op, SinkFunc const &sink)
 {
 
      std::vector<typename std::result_of<GenFunc()>::type::value_type> buffer;
@@ -115,7 +115,7 @@ template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
 
 
 template <typename TaskFunc, typename RedFunc>
-ReduceObj<parallel_execution_omp,TaskFunc, RedFunc> stream_reduce(parallel_execution_omp p, TaskFunc && taskf, RedFunc && red){
+ReduceObj<parallel_execution_omp,TaskFunc, RedFunc> stream_reduce(parallel_execution_omp const &p, TaskFunc && taskf, RedFunc && red){
    return ReduceObj<parallel_execution_omp, TaskFunc, RedFunc>(p,taskf, red);
 }
 }

--- a/include/ppi_omp/stream_reduce_omp.h
+++ b/include/ppi_omp/stream_reduce_omp.h
@@ -29,7 +29,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
- void stream_reduce(parallel_execution_omp const &p, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red, OutputType &reduce_value ){
+ void stream_reduce(parallel_execution_omp &p, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red, OutputType &reduce_value ){
 	
     Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.lockfree);
     Queue<optional<OutputType>> end_queue(DEFAULT_SIZE, p.lockfree);
@@ -82,7 +82,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename Out
 
 
 template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
- void stream_reduce(parallel_execution_omp const &p, GenFunc &&in, int windowsize, int offset, ReduceOperator && op, SinkFunc &&sink)
+ void stream_reduce(parallel_execution_omp &p, GenFunc &&in, int windowsize, int offset, ReduceOperator && op, SinkFunc &&sink)
 {
 
      std::vector<typename std::result_of<GenFunc()>::type::value_type> buffer;
@@ -115,7 +115,7 @@ template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
 
 
 template <typename TaskFunc, typename RedFunc>
-ReduceObj<parallel_execution_omp,TaskFunc, RedFunc> stream_reduce(parallel_execution_omp const &p, TaskFunc && taskf, RedFunc && red){
+ReduceObj<parallel_execution_omp,TaskFunc, RedFunc> stream_reduce(parallel_execution_omp &p, TaskFunc && taskf, RedFunc && red){
    return ReduceObj<parallel_execution_omp, TaskFunc, RedFunc>(p,taskf, red);
 }
 }

--- a/include/ppi_seq/divideandconquer_seq.h
+++ b/include/ppi_seq/divideandconquer_seq.h
@@ -24,7 +24,7 @@ namespace grppi{
 using namespace std;
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void divide_and_conquer(sequential_execution s, Input &problem, Output &output, DivFunc const &divide,
+ void divide_and_conquer(sequential_execution const &s, Input &problem, Output &output, DivFunc const &divide,
                                TaskFunc const &task, MergeFunc const &merge) {
      
     auto subproblems = divide(problem);

--- a/include/ppi_seq/divideandconquer_seq.h
+++ b/include/ppi_seq/divideandconquer_seq.h
@@ -24,7 +24,7 @@ namespace grppi{
 using namespace std;
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void divide_and_conquer(sequential_execution const &s, Input &problem, Output &output, DivFunc &&divide,
+ void divide_and_conquer(sequential_execution &s, Input &problem, Output &output, DivFunc &&divide,
                                TaskFunc &&task, MergeFunc &&merge) {
      
     auto subproblems = divide(problem);

--- a/include/ppi_seq/farm_seq.h
+++ b/include/ppi_seq/farm_seq.h
@@ -48,7 +48,7 @@ void farm(sequential_execution , GenFunc &&in, TaskFunc && taskf, SinkFunc &&sin
 
 
 template <typename TaskFunc>
-FarmObj<sequential_execution,TaskFunc> farm(sequential_execution s, TaskFunc && taskf){
+FarmObj<sequential_execution,TaskFunc> farm(sequential_execution &s, TaskFunc && taskf){
    return FarmObj<sequential_execution, TaskFunc>(s ,taskf);
 }
 }

--- a/include/ppi_seq/map_seq.h
+++ b/include/ppi_seq/map_seq.h
@@ -25,7 +25,7 @@ using namespace std;
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>
- void map(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf ) {
+ void map(sequential_execution &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf ) {
 
     while( first != last ) {
        *firstOut = taskf(*first);
@@ -35,7 +35,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc>
 }
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
- void map(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, MoreIn ... inputs ) {
+ void map(sequential_execution &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, MoreIn ... inputs ) {
 
     while( first != last ) {
         *firstOut = taskf( *first, *inputs ... );

--- a/include/ppi_seq/map_seq.h
+++ b/include/ppi_seq/map_seq.h
@@ -25,7 +25,7 @@ using namespace std;
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>
- void map(sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf ) {
+ void map(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf ) {
     while( first != last ) {
        *firstOut = taskf(*first);
        first++;
@@ -34,7 +34,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc>
 }
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
- void map(sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs ) {
+ void map(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs ) {
     while( first != last ) {
         *firstOut = taskf( *first, *inputs ... );
         advance_iterators( inputs... );

--- a/include/ppi_seq/mapreduce_seq.h
+++ b/include/ppi_seq/mapreduce_seq.h
@@ -25,7 +25,7 @@
 
 namespace grppi{
 template < typename InputIt, typename OutputIt, typename MapFunc, typename ReduceOperator, typename ... MoreIn >
-void map_reduce (sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, MapFunc const & map, ReduceOperator op, MoreIn ... inputs) {
+void map_reduce (sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, MapFunc const & map, ReduceOperator op, MoreIn ... inputs) {
     while( first != last ) {
        auto mapresult = map(*first, inputs ... );
        reduce(s, mapresult.begin(), mapresult.end(), *firstOut, op);

--- a/include/ppi_seq/mapreduce_seq.h
+++ b/include/ppi_seq/mapreduce_seq.h
@@ -25,7 +25,7 @@
 
 namespace grppi{
 template < typename InputIt, typename OutputIt, typename MapFunc, typename ReduceOperator, typename ... MoreIn >
-void map_reduce (sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, MapFunc && map, ReduceOperator op, MoreIn ... inputs) {
+void map_reduce (sequential_execution &s, InputIt first, InputIt last, OutputIt firstOut, MapFunc && map, ReduceOperator op, MoreIn ... inputs) {
 
     while( first != last ) {
        auto mapresult = map(*first, inputs ... );

--- a/include/ppi_seq/pipeline_seq.h
+++ b/include/ppi_seq/pipeline_seq.h
@@ -42,13 +42,13 @@ template <typename InType, int currentStage, typename ...Stages>
 
 //Last stage
 template <typename Stream, typename Stage>
-void stages(sequential_execution s, Stream st, Stage se ) {
+void stages(sequential_execution const &s, Stream st, Stage se ) {
     se( st );
 }
 
 //Filter stage
 template <typename task, typename Stream, typename... Stages>
-void stages(sequential_execution s, Stream st, FilterObj<sequential_execution, task> se, Stages ... sgs ) {
+void stages(sequential_execution const &s, Stream st, FilterObj<sequential_execution, task> se, Stages ... sgs ) {
 //   auto out = se.run(st);
      if((*se.task)(st))
         stages(s, st, sgs ... );
@@ -56,7 +56,7 @@ void stages(sequential_execution s, Stream st, FilterObj<sequential_execution, t
 
 
 template <typename task, template <typename,typename> class Stage, typename Stream, typename... Stages>
-void stages(sequential_execution s, Stream st, Stage<sequential_execution, task> se, Stages ... sgs ) {
+void stages(sequential_execution const &s, Stream st, Stage<sequential_execution, task> se, Stages ... sgs ) {
 //   auto out = se.run(st);
      auto out = (*se.task)(st);
      stages(s, out, sgs ... );
@@ -64,14 +64,14 @@ void stages(sequential_execution s, Stream st, Stage<sequential_execution, task>
 
 //Intermediate stages
 template <typename Stage, typename Stream, typename... Stages>
-void stages(sequential_execution s, Stream st, Stage se, Stages ... sgs ) {
+void stages(sequential_execution const &s, Stream st, Stage se, Stages ... sgs ) {
     auto out = se( st );
     stages(s, out, sgs ... );
 }
 
 //First stage
 template <typename FuncIn, typename = typename std::result_of<FuncIn()>::type, typename ...Stages>
-void pipeline(sequential_execution s, FuncIn in, Stages... sts ) {
+void pipeline(sequential_execution const &s, FuncIn in, Stages... sts ) {
     while( 1 ) {
         auto k = in();
         if( !k )

--- a/include/ppi_seq/pipeline_seq.h
+++ b/include/ppi_seq/pipeline_seq.h
@@ -42,13 +42,13 @@ template <typename InType, int currentStage, typename ...Stages>
 
 //Last stage
 template <typename Stream, typename Stage>
-void stages(sequential_execution const &s, Stream st, Stage && se ) {
+void stages(sequential_execution &s, Stream st, Stage && se ) {
     se( st );
 }
 
 //Filter stage
 template <typename task, typename Stream, typename... Stages>
-void stages(sequential_execution const &s, Stream st, FilterObj<sequential_execution, task> && se, Stages && ... sgs ) {
+void stages(sequential_execution &s, Stream st, FilterObj<sequential_execution, task> && se, Stages && ... sgs ) {
 
 //   auto out = se.run(st);
      if((*se.task)(st))
@@ -57,7 +57,7 @@ void stages(sequential_execution const &s, Stream st, FilterObj<sequential_execu
 
 
 template <typename task, template <typename,typename> class Stage, typename Stream, typename... Stages>
-void stages(sequential_execution const &s, Stream st, Stage<sequential_execution, task> && se, Stages && ... sgs ) {
+void stages(sequential_execution &s, Stream st, Stage<sequential_execution, task> && se, Stages && ... sgs ) {
 
 //   auto out = se.run(st);
      auto out = (*se.task)(st);
@@ -66,14 +66,14 @@ void stages(sequential_execution const &s, Stream st, Stage<sequential_execution
 
 //Intermediate stages
 template <typename Stage, typename Stream, typename... Stages>
-void stages(sequential_execution const &s, Stream st, Stage && se, Stages && ... sgs ) {
+void stages(sequential_execution &s, Stream st, Stage && se, Stages && ... sgs ) {
     auto out = se( st );
     stages(s, out, std::forward<Stages>(sgs) ... );
 }
 
 //First stage
 template <typename FuncIn, typename = typename std::result_of<FuncIn()>::type, typename ...Stages>
-void pipeline(sequential_execution const &s, FuncIn && in, Stages && ... sgs ) {
+void pipeline(sequential_execution &s, FuncIn && in, Stages && ... sgs ) {
 
     while( 1 ) {
         auto k = in();

--- a/include/ppi_seq/reduce_seq.h
+++ b/include/ppi_seq/reduce_seq.h
@@ -27,7 +27,7 @@ namespace grppi{
 
 template < typename InputIt, typename Output, typename ReduceOperator>
  typename std::enable_if<!is_iterator<Output>::value, void>::type 
-reduce(sequential_execution const &s, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
+reduce(sequential_execution &s, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
     typename ReduceOperator::result_type identityVal = !op(false,true);
     while( first != last ) {
        identityVal = op(identityVal, *first);
@@ -37,7 +37,7 @@ reduce(sequential_execution const &s, InputIt first, InputIt last, Output & firs
 }
 
 template < typename InputIt, typename ReduceOperator>
- typename ReduceOperator::result_type reduce(sequential_execution const &s, InputIt first, InputIt last, ReduceOperator op) {
+ typename ReduceOperator::result_type reduce(sequential_execution &s, InputIt first, InputIt last, ReduceOperator op) {
     typename ReduceOperator::result_type identityVal = !op(false,true);
     auto firstOut = identityVal;
 //  first++;
@@ -51,7 +51,7 @@ template < typename InputIt, typename ReduceOperator>
 
 template < typename InputIt, typename OutputIt, typename RedFunc>
  typename  std::enable_if<is_iterator<OutputIt>::value, void>::type 
-reduce (sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, RedFunc && reduce) {
+reduce (sequential_execution &s, InputIt first, InputIt last, OutputIt firstOut, RedFunc && reduce) {
 
     while( first != last ) {
        reduce(*first, *firstOut);

--- a/include/ppi_seq/reduce_seq.h
+++ b/include/ppi_seq/reduce_seq.h
@@ -27,7 +27,7 @@ namespace grppi{
 
 template < typename InputIt, typename Output, typename ReduceOperator>
  typename std::enable_if<!is_iterator<Output>::value, void>::type 
-reduce(sequential_execution s, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
+reduce(sequential_execution const &s, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
     typename ReduceOperator::result_type identityVal = !op(false,true);
     while( first != last ) {
        identityVal = op(identityVal, *first);
@@ -37,7 +37,7 @@ reduce(sequential_execution s, InputIt first, InputIt last, Output & firstOut, R
 }
 
 template < typename InputIt, typename ReduceOperator>
- typename ReduceOperator::result_type reduce(sequential_execution s, InputIt first, InputIt last, ReduceOperator op) {
+ typename ReduceOperator::result_type reduce(sequential_execution const &s, InputIt first, InputIt last, ReduceOperator op) {
     typename ReduceOperator::result_type identityVal = !op(false,true);
     auto firstOut = identityVal;
 //  first++;
@@ -51,7 +51,7 @@ template < typename InputIt, typename ReduceOperator>
 
 template < typename InputIt, typename OutputIt, typename RedFunc>
  typename  std::enable_if<is_iterator<OutputIt>::value, void>::type 
-reduce (sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, RedFunc const & reduce) {
+reduce (sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, RedFunc const & reduce) {
     while( first != last ) {
        reduce(*first, *firstOut);
        first++;
@@ -62,7 +62,7 @@ reduce (sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, 
 /*
 template < typename InputIt, typename Output, typename RedFunc, typename FinalReduce>
  typename std::enable_if<!is_iterator<Output>::value, void>::type
-Reduce(sequential_execution s, InputIt first, InputIt last, Output & firstOut, RedFunc const & reduce, FinalReduce const & freduce) {
+Reduce(sequential_execution const &s, InputIt first, InputIt last, Output & firstOut, RedFunc const & reduce, FinalReduce const & freduce) {
     while( first != last ) {
        reduce(*first, firstOut);
        first++;

--- a/include/ppi_seq/stencil_seq.h
+++ b/include/ppi_seq/stencil_seq.h
@@ -24,7 +24,7 @@
 using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
- void stencil(sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
+ void stencil(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
     while( first != last ) {
        auto neighbors = neighbor(first);   
        *firstOut = taskf(first, neighbors);
@@ -37,7 +37,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc, typename NFunc>
- void stencil(sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
+ void stencil(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
     while( first != last ) {
         auto neighbors = neighbor(first);
         *firstOut = taskf(first, neighbors, *inputs ...);

--- a/include/ppi_seq/stencil_seq.h
+++ b/include/ppi_seq/stencil_seq.h
@@ -24,7 +24,7 @@
 using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
- void stencil(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {
+ void stencil(sequential_execution &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {
     while( first != last ) {
        auto neighbors = neighbor(first);   
        *firstOut = taskf(first, neighbors);
@@ -37,7 +37,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc, typename NFunc>
- void stencil(sequential_execution const &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor, MoreIn ... inputs ) {
+ void stencil(sequential_execution &s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor, MoreIn ... inputs ) {
     while( first != last ) {
         auto neighbors = neighbor(first);
         *firstOut = taskf(first, neighbors, *inputs ...);

--- a/include/ppi_seq/stream_filter_seq.h
+++ b/include/ppi_seq/stream_filter_seq.h
@@ -49,7 +49,7 @@ void stream_filter( GenFunc && in, FilterFunc && filter, OutFunc && out ) {
 }
 
 template <typename FilterFunc>
-FilterObj<sequential_execution, FilterFunc> stream_filter(sequential_execution s, FilterFunc && taskf){
+FilterObj<sequential_execution, FilterFunc> stream_filter(sequential_execution &s, FilterFunc && taskf){
    return FilterObj<sequential_execution, FilterFunc>(s, taskf);
 }
 

--- a/include/ppi_seq/stream_iteration_seq.h
+++ b/include/ppi_seq/stream_iteration_seq.h
@@ -49,7 +49,7 @@ template<typename GenFunc, typename TaskFunc, typename Predicate, typename OutFu
 }
 
 template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Stages>
- void stream_iteration(sequential_execution s, GenFunc const & in, PipelineObj<sequential_execution, Stages...> const & f, Predicate const & condition, OutFunc const & out){
+ void stream_iteration(sequential_execution const &s, GenFunc const & in, PipelineObj<sequential_execution, Stages...> const & f, Predicate const & condition, OutFunc const & out){
    while(1){
        auto k = in();
        if(!k) break; 

--- a/include/ppi_seq/stream_iteration_seq.h
+++ b/include/ppi_seq/stream_iteration_seq.h
@@ -49,7 +49,7 @@ template<typename GenFunc, typename TaskFunc, typename Predicate, typename OutFu
 }
 
 template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Stages>
- void stream_iteration(sequential_execution const &s, GenFunc && in, PipelineObj<sequential_execution, Stages...> && f, Predicate && condition, OutFunc && out){
+ void stream_iteration(sequential_execution &s, GenFunc && in, PipelineObj<sequential_execution, Stages...> && f, Predicate && condition, OutFunc && out){
    while(1){
        auto k = in();
        if(!k) break; 

--- a/include/ppi_seq/stream_reduce_seq.hpp
+++ b/include/ppi_seq/stream_reduce_seq.hpp
@@ -27,7 +27,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
- void stream_reduce(sequential_execution s, GenFunc const &in, TaskFunc const & taskf, ReduceFunc const &red, OutputType &reduce_value ) {
+ void stream_reduce(sequential_execution const &s, GenFunc const &in, TaskFunc const & taskf, ReduceFunc const &red, OutputType &reduce_value ) {
 
     while( 1 ) {
         auto k = in();
@@ -40,7 +40,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename Out
 
 
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc>
- void stream_reduce(sequential_execution s, GenFunc const &in, TaskFunc const & taskf, ReduceFunc const &red) {
+ void stream_reduce(sequential_execution const &s, GenFunc const &in, TaskFunc const & taskf, ReduceFunc const &red) {
     while( 1 ) {
         auto k = in();
         if( !k )
@@ -52,7 +52,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc>
 
 
 template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
- void stream_reduce(sequential_execution s, GenFunc const &in, int windowsize, int offset, ReduceOperator const & op, SinkFunc const &sink)
+ void stream_reduce(sequential_execution const &s, GenFunc const &in, int windowsize, int offset, ReduceOperator const & op, SinkFunc const &sink)
 {
      
      std::vector<typename std::result_of<GenFunc()>::type::value_type> buffer;

--- a/include/ppi_seq/stream_reduce_seq.hpp
+++ b/include/ppi_seq/stream_reduce_seq.hpp
@@ -27,7 +27,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
- void stream_reduce(sequential_execution const &s, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red, OutputType &reduce_value ) {
+ void stream_reduce(sequential_execution &s, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red, OutputType &reduce_value ) {
 
     while( 1 ) {
         auto k = in();
@@ -40,7 +40,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename Out
 
 
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc>
- void stream_reduce(sequential_execution const &s, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red) {
+ void stream_reduce(sequential_execution &s, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red) {
     while( 1 ) {
         auto k = in();
         if( !k )
@@ -52,7 +52,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc>
 
 
 template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
- void stream_reduce(sequential_execution const &s, GenFunc &&in, int windowsize, int offset, ReduceOperator && op, SinkFunc &&sink)
+ void stream_reduce(sequential_execution &s, GenFunc &&in, int windowsize, int offset, ReduceOperator && op, SinkFunc &&sink)
 {
      
      std::vector<typename std::result_of<GenFunc()>::type::value_type> buffer;

--- a/include/ppi_tbb/divideandconquer_tbb.h
+++ b/include/ppi_tbb/divideandconquer_tbb.h
@@ -27,7 +27,7 @@
 namespace grppi{
 using namespace std;
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void internal_divide_and_conquer(parallel_execution_tbb p, Input & problem, Output & output,
+ void internal_divide_and_conquer(parallel_execution_tbb const &p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge, std::atomic<int>& num_threads) {
     
    
@@ -74,7 +74,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 }
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void divide_and_conquer(parallel_execution_tbb p, Input & problem, Output & output,
+ void divide_and_conquer(parallel_execution_tbb const &p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge) {
 
     std::atomic<int> num_threads( p.num_threads );

--- a/include/ppi_tbb/divideandconquer_tbb.h
+++ b/include/ppi_tbb/divideandconquer_tbb.h
@@ -27,7 +27,7 @@
 namespace grppi{
 using namespace std;
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void internal_divide_and_conquer(parallel_execution_tbb const &p, Input & problem, Output & output,
+ void internal_divide_and_conquer(parallel_execution_tbb &p, Input & problem, Output & output,
             DivFunc && divide, TaskFunc && task, MergeFunc && merge, std::atomic<int>& num_threads) {
    
     if(num_threads.load()>0){
@@ -73,7 +73,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 }
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void divide_and_conquer(parallel_execution_tbb const &p, Input & problem, Output & output,
+ void divide_and_conquer(parallel_execution_tbb &p, Input & problem, Output & output,
             DivFunc && divide, TaskFunc && task, MergeFunc && merge) {
 
     std::atomic<int> num_threads( p.num_threads );

--- a/include/ppi_tbb/farm_tbb.h
+++ b/include/ppi_tbb/farm_tbb.h
@@ -26,7 +26,7 @@
 #include <tbb/tbb.h>
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename SinkFunc>
- void farm(parallel_execution_tbb p, GenFunc const &in, TaskFunc const & taskf , SinkFunc const &sink) {
+ void farm(parallel_execution_tbb const &p, GenFunc const &in, TaskFunc const & taskf , SinkFunc const &sink) {
 
     tbb::task_group g;
     Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.lockfree);
@@ -85,7 +85,7 @@ template <typename GenFunc, typename TaskFunc, typename SinkFunc>
 
 
 template <typename GenFunc, typename TaskFunc>
- void farm(parallel_execution_tbb p, GenFunc const &in, TaskFunc const & taskf ) {
+ void farm(parallel_execution_tbb const &p, GenFunc const &in, TaskFunc const & taskf ) {
 
     tbb::task_group g;
     Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE, p.lockfree);

--- a/include/ppi_tbb/farm_tbb.h
+++ b/include/ppi_tbb/farm_tbb.h
@@ -26,7 +26,7 @@
 #include <tbb/tbb.h>
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename SinkFunc>
- void farm(parallel_execution_tbb const &p, GenFunc &&in, TaskFunc && taskf , SinkFunc &&sink) {
+ void farm(parallel_execution_tbb &p, GenFunc &&in, TaskFunc && taskf , SinkFunc &&sink) {
 
     tbb::task_group g;
     Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.lockfree);
@@ -85,7 +85,7 @@ template <typename GenFunc, typename TaskFunc, typename SinkFunc>
 
 
 template <typename GenFunc, typename TaskFunc>
- void farm(parallel_execution_tbb const &p, GenFunc &&in, TaskFunc && taskf ) {
+ void farm(parallel_execution_tbb &p, GenFunc &&in, TaskFunc && taskf ) {
 
     tbb::task_group g;
     Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE, p.lockfree);
@@ -122,7 +122,7 @@ template <typename GenFunc, typename TaskFunc>
 
 
 template <typename TaskFunc>
-FarmObj<parallel_execution_tbb,TaskFunc> farm(parallel_execution_tbb p, TaskFunc && taskf){
+FarmObj<parallel_execution_tbb,TaskFunc> farm(parallel_execution_tbb &p, TaskFunc && taskf){
    return FarmObj<parallel_execution_tbb, TaskFunc>(p,taskf);
 }
 }

--- a/include/ppi_tbb/map_tbb.h
+++ b/include/ppi_tbb/map_tbb.h
@@ -27,7 +27,7 @@
 namespace grppi{
 using namespace std;
 template <typename InputIt, typename OutputIt, typename TaskFunc>
-void map(parallel_execution_tbb p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc const & taskf){
+void map(parallel_execution_tbb const &p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc const & taskf){
    tbb::parallel_for(static_cast<std::size_t>(0),static_cast<std::size_t>( (last-first) ), [&] (std::size_t index){
            auto current = (firstOut+index);
            *current = taskf(*(first+index));
@@ -38,7 +38,7 @@ void map(parallel_execution_tbb p, InputIt first,InputIt last, OutputIt firstOut
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
-void map(parallel_execution_tbb p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs){
+void map(parallel_execution_tbb const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs){
    tbb::parallel_for(static_cast<std::size_t>(0),static_cast<std::size_t>( (last-first) ), [&] (std::size_t index){
            auto current = (firstOut+index);
            *current = taskf(*(first+index));

--- a/include/ppi_tbb/map_tbb.h
+++ b/include/ppi_tbb/map_tbb.h
@@ -27,7 +27,7 @@
 namespace grppi{
 using namespace std;
 template <typename InputIt, typename OutputIt, typename TaskFunc>
-void map(parallel_execution_tbb const &p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc && taskf){
+void map(parallel_execution_tbb &p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc && taskf){
    tbb::parallel_for(static_cast<std::size_t>(0),static_cast<std::size_t>( (last-first) ), [&] (std::size_t index){
            auto current = (firstOut+index);
            *current = taskf(*(first+index));
@@ -38,7 +38,7 @@ void map(parallel_execution_tbb const &p, InputIt first,InputIt last, OutputIt f
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
-void map(parallel_execution_tbb const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, MoreIn ... inputs){
+void map(parallel_execution_tbb &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, MoreIn ... inputs){
    tbb::parallel_for(static_cast<std::size_t>(0),static_cast<std::size_t>( (last-first) ), [&] (std::size_t index){
            auto current = (firstOut+index);
            *current = taskf(*(first+index), *(inputs+index)...);

--- a/include/ppi_tbb/pipeline_tbb.h
+++ b/include/ppi_tbb/pipeline_tbb.h
@@ -30,14 +30,14 @@ using namespace std;
 namespace grppi{
 //Last stage
 template <typename Stream, typename Stage>
- const tbb::interface6::filter_t<Stream, void> stages(parallel_execution_tbb p, Stream st, Stage s ) {
+ const tbb::interface6::filter_t<Stream, void> stages(parallel_execution_tbb const &p, Stream st, Stage s ) {
     return tbb::make_filter<Stream, void>( tbb::filter::serial_in_order, s );
 }
 
 //Intermediate stages
 template <typename Task, template<typename, typename> class Stage, typename Stream, typename ... Stages>
  const tbb::interface6::filter_t<Stream, void> 
-stages(parallel_execution_tbb p, Stream st, Stage<parallel_execution_tbb, Task> se, Stages ... sgs ) {
+stages(parallel_execution_tbb const &p, Stream st, Stage<parallel_execution_tbb, Task> se, Stages ... sgs ) {
     typedef typename std::result_of<Task(Stream)>::type outputType;
     outputType k;
     return tbb::make_filter<Stream, outputType>( tbb::filter::parallel, (*se.task) ) & stages(p, k, sgs ... );
@@ -45,7 +45,7 @@ stages(parallel_execution_tbb p, Stream st, Stage<parallel_execution_tbb, Task> 
 
 template <typename Stage, typename Stream, typename ... Stages>
  const tbb::interface6::filter_t<Stream, void> 
-stages(parallel_execution_tbb p, Stream st, Stage se, Stages ... sgs ) {
+stages(parallel_execution_tbb const &p, Stream st, Stage se, Stages ... sgs ) {
     typedef typename std::result_of<Stage(Stream)>::type outputType;
     outputType k;
     return tbb::make_filter<Stream, outputType>( tbb::filter::serial_in_order, se ) & stages(p, k, sgs ... );
@@ -55,7 +55,7 @@ stages(parallel_execution_tbb p, Stream st, Stage se, Stages ... sgs ) {
 template <typename FuncIn, typename = typename std::result_of<FuncIn()>::type,
           typename ...Stages,
           requires_no_arguments<FuncIn> = 0>
-void pipeline(parallel_execution_tbb p, FuncIn in, Stages ... sts ) {
+void pipeline(parallel_execution_tbb const &p, FuncIn in, Stages ... sts ) {
     typedef typename std::result_of<FuncIn()>::type::value_type outputType;
     outputType k;
     const auto stage = tbb::make_filter<void, outputType>(

--- a/include/ppi_tbb/pipeline_tbb.h
+++ b/include/ppi_tbb/pipeline_tbb.h
@@ -30,14 +30,14 @@ using namespace std;
 namespace grppi{
 //Last stage
 template <typename Stream, typename Stage>
- const tbb::interface6::filter_t<Stream, void> stages(parallel_execution_tbb const &p, Stream st, Stage s ) {
+ const tbb::interface6::filter_t<Stream, void> stages(parallel_execution_tbb &p, Stream st, Stage s ) {
     return tbb::make_filter<Stream, void>( tbb::filter::serial_in_order, s );
 }
 
 //Intermediate stages
 template <typename Task, template<typename, typename> class Stage, typename Stream, typename ... Stages>
  const tbb::interface6::filter_t<Stream, void> 
-stages(parallel_execution_tbb const &p, Stream st, Stage<parallel_execution_tbb, Task> se, Stages && ... sgs ) {
+stages(parallel_execution_tbb &p, Stream st, Stage<parallel_execution_tbb, Task> se, Stages && ... sgs ) {
     typedef typename std::result_of<Task(Stream)>::type outputType;
     outputType k;
     return tbb::make_filter<Stream, outputType>( tbb::filter::parallel, (*se.task) ) & stages(p, k, std::forward<Stages>(sgs) ... );
@@ -45,7 +45,7 @@ stages(parallel_execution_tbb const &p, Stream st, Stage<parallel_execution_tbb,
 
 template <typename Stage, typename Stream, typename ... Stages>
  const tbb::interface6::filter_t<Stream, void> 
-stages(parallel_execution_tbb const &p, Stream st, Stage se, Stages && ... sgs ) {
+stages(parallel_execution_tbb &p, Stream st, Stage se, Stages && ... sgs ) {
     typedef typename std::result_of<Stage(Stream)>::type outputType;
     outputType k;
     return tbb::make_filter<Stream, outputType>( tbb::filter::serial_in_order, se ) & stages(p, k, std::forward<Stages>(sgs) ... );
@@ -55,7 +55,7 @@ stages(parallel_execution_tbb const &p, Stream st, Stage se, Stages && ... sgs )
 template <typename FuncIn, typename = typename std::result_of<FuncIn()>::type,
           typename ...Stages,
           requires_no_arguments<FuncIn> = 0>
-void pipeline(parallel_execution_tbb const &p, FuncIn in, Stages && ... sts ) {
+void pipeline(parallel_execution_tbb &p, FuncIn in, Stages && ... sts ) {
     typedef typename std::result_of<FuncIn()>::type::value_type outputType;
     outputType k;
     const auto stage = tbb::make_filter<void, outputType>(

--- a/include/ppi_tbb/reduce_tbb.h
+++ b/include/ppi_tbb/reduce_tbb.h
@@ -31,7 +31,7 @@ using namespace std;
 namespace grppi{
 template < typename InputIt, typename Output,typename ReduceOperator>
  typename std::enable_if<!is_iterator<Output>::value, void>::type 
-reduce(parallel_execution_tbb const &p, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
+reduce(parallel_execution_tbb &p, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
    typename ReduceOperator::result_type identityVal = !op(false,true); 
    //FIXME: Necesita el valor inicial de la operacion
    firstOut = op(firstOut, 
@@ -54,7 +54,7 @@ reduce(parallel_execution_tbb const &p, InputIt first, InputIt last, Output & fi
 
 template < typename InputIt, typename ReduceOperator>
  typename ReduceOperator::result_type
-reduce(parallel_execution_tbb const &p, InputIt first, InputIt last, ReduceOperator op) {
+reduce(parallel_execution_tbb &p, InputIt first, InputIt last, ReduceOperator op) {
    typename ReduceOperator::result_type identityVal = !op(false, true); 
    //FIXME: Necesita el valor inicial de la operacion
    return tbb::parallel_reduce(tbb::blocked_range<InputIt>( first, last ), identityVal,
@@ -76,7 +76,7 @@ reduce(parallel_execution_tbb const &p, InputIt first, InputIt last, ReduceOpera
 
 template < typename InputIt, typename OutputIt, typename RedFunc>
  typename  std::enable_if<is_iterator<OutputIt>::value, void>::type
-reduce (parallel_execution_tbb const &s, InputIt first, InputIt last, OutputIt firstOut, RedFunc && reduce) {
+reduce (parallel_execution_tbb &s, InputIt first, InputIt last, OutputIt firstOut, RedFunc && reduce) {
     while( first != last ) {
        reduce(*first, *firstOut);
        first++;

--- a/include/ppi_tbb/reduce_tbb.h
+++ b/include/ppi_tbb/reduce_tbb.h
@@ -76,7 +76,7 @@ reduce(parallel_execution_tbb const &p, InputIt first, InputIt last, ReduceOpera
 
 template < typename InputIt, typename OutputIt, typename RedFunc>
  typename  std::enable_if<is_iterator<OutputIt>::value, void>::type
-reduce (parallel_execution_tbb s, InputIt first, InputIt last, OutputIt firstOut, RedFunc const & reduce) {
+reduce (parallel_execution_tbb const &s, InputIt first, InputIt last, OutputIt firstOut, RedFunc const & reduce) {
     while( first != last ) {
        reduce(*first, *firstOut);
        first++;

--- a/include/ppi_tbb/reduce_tbb.h
+++ b/include/ppi_tbb/reduce_tbb.h
@@ -31,7 +31,7 @@ using namespace std;
 namespace grppi{
 template < typename InputIt, typename Output,typename ReduceOperator>
  typename std::enable_if<!is_iterator<Output>::value, void>::type 
-reduce(parallel_execution_tbb p, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
+reduce(parallel_execution_tbb const &p, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
    typename ReduceOperator::result_type identityVal = !op(false,true); 
    //FIXME: Necesita el valor inicial de la operacion
    firstOut = op(firstOut, 
@@ -54,7 +54,7 @@ reduce(parallel_execution_tbb p, InputIt first, InputIt last, Output & firstOut,
 
 template < typename InputIt, typename ReduceOperator>
  typename ReduceOperator::result_type
-reduce(parallel_execution_tbb p, InputIt first, InputIt last, ReduceOperator op) {
+reduce(parallel_execution_tbb const &p, InputIt first, InputIt last, ReduceOperator op) {
    typename ReduceOperator::result_type identityVal = !op(false, true); 
    //FIXME: Necesita el valor inicial de la operacion
    return tbb::parallel_reduce(tbb::blocked_range<InputIt>( first, last ), identityVal,

--- a/include/ppi_tbb/stencil_tbb.h
+++ b/include/ppi_tbb/stencil_tbb.h
@@ -27,7 +27,7 @@
 using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_tbb const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {
+ void stencil(parallel_execution_tbb &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {
 
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
@@ -67,7 +67,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_tbb const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor, MoreIn ... inputs ) {
+ void stencil(parallel_execution_tbb &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor, MoreIn ... inputs ) {
 
      int numElements = last - first;
      int elemperthr = numElements/p.num_threads;

--- a/include/ppi_tbb/stencil_tbb.h
+++ b/include/ppi_tbb/stencil_tbb.h
@@ -27,7 +27,7 @@
 using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_tbb p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
+ void stencil(parallel_execution_tbb const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor ) {
 
     int numElements = last - first;
     int elemperthr = numElements/p.num_threads;
@@ -67,7 +67,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc, typename NFunc>
- void stencil(parallel_execution_tbb p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
+ void stencil(parallel_execution_tbb const &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, NFunc const & neighbor, MoreIn ... inputs ) {
 
      int numElements = last - first;
      int elemperthr = numElements/p.num_threads;

--- a/include/ppi_tbb/stream_filter_tbb.h
+++ b/include/ppi_tbb/stream_filter_tbb.h
@@ -27,7 +27,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
- void stream_filter(parallel_execution_tbb const &p, GenFunc && in, FilterFunc && filter, OutFunc && out ) {
+ void stream_filter(parallel_execution_tbb &p, GenFunc && in, FilterFunc && filter, OutFunc && out ) {
 
     tbb::task_group g;
 
@@ -128,7 +128,7 @@ template <typename GenFunc, typename FilterFunc, typename OutFunc>
 }
 
 template <typename FilterFunc>
-FilterObj<parallel_execution_tbb, FilterFunc> stream_filter(parallel_execution_tbb p, FilterFunc && taskf){
+FilterObj<parallel_execution_tbb, FilterFunc> stream_filter(parallel_execution_tbb &p, FilterFunc && taskf){
    return FilterObj<parallel_execution_tbb, FilterFunc>(p, taskf);
 
 }

--- a/include/ppi_tbb/stream_filter_tbb.h
+++ b/include/ppi_tbb/stream_filter_tbb.h
@@ -27,7 +27,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
- void stream_filter(parallel_execution_tbb p, GenFunc const & in, FilterFunc const & filter, OutFunc const & out ) {
+ void stream_filter(parallel_execution_tbb const &p, GenFunc const & in, FilterFunc const & filter, OutFunc const & out ) {
 
     tbb::task_group g;
 

--- a/include/ppi_tbb/stream_reduce_tbb.h
+++ b/include/ppi_tbb/stream_reduce_tbb.h
@@ -78,7 +78,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename Out
 }
 
 template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
- void stream_reduce(parallel_execution_tbb s, GenFunc const &in, int windowsize, int offset, ReduceOperator const & op, SinkFunc const &sink)
+ void stream_reduce(parallel_execution_tbb const &s, GenFunc const &in, int windowsize, int offset, ReduceOperator const & op, SinkFunc const &sink)
 {
 
      std::vector<typename std::result_of<GenFunc()>::type::value_type> buffer;

--- a/include/ppi_tbb/stream_reduce_tbb.h
+++ b/include/ppi_tbb/stream_reduce_tbb.h
@@ -29,7 +29,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
- void stream_reduce(parallel_execution_tbb const &p, GenFunc &&in, TaskFunc &&taskf, ReduceFunc &&red, OutputType &reduce_value ){
+ void stream_reduce(parallel_execution_tbb &p, GenFunc &&in, TaskFunc &&taskf, ReduceFunc &&red, OutputType &reduce_value ){
 
     Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.lockfree);
     Queue<optional<OutputType>> end_queue (DEFAULT_SIZE, p.lockfree);
@@ -78,7 +78,7 @@ template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename Out
 }
 
 template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
- void stream_reduce(parallel_execution_tbb const &s, GenFunc &&in, int windowsize, int offset, ReduceOperator && op, SinkFunc &&sink)
+ void stream_reduce(parallel_execution_tbb &s, GenFunc &&in, int windowsize, int offset, ReduceOperator && op, SinkFunc &&sink)
 {
 
      std::vector<typename std::result_of<GenFunc()>::type::value_type> buffer;
@@ -109,7 +109,7 @@ template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
 }
 
 template <typename TaskFunc, typename RedFunc>
-ReduceObj<parallel_execution_tbb,TaskFunc, RedFunc> stream_reduce(parallel_execution_thr p, TaskFunc && taskf, RedFunc && red){
+ReduceObj<parallel_execution_tbb,TaskFunc, RedFunc> stream_reduce(parallel_execution_thr &p, TaskFunc && taskf, RedFunc && red){
    return ReduceObj<parallel_execution_tbb, TaskFunc, RedFunc>(p,taskf, red);
 }
 }

--- a/include/ppi_tbb/stream_reduce_tbb.h
+++ b/include/ppi_tbb/stream_reduce_tbb.h
@@ -29,7 +29,7 @@
 using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
- void stream_reduce(parallel_execution_tbb p, GenFunc const &in, TaskFunc const &taskf, ReduceFunc const &red, OutputType &reduce_value ){
+ void stream_reduce(parallel_execution_tbb const &p, GenFunc const &in, TaskFunc const &taskf, ReduceFunc const &red, OutputType &reduce_value ){
 
     Queue<typename std::result_of<GenFunc()>::type> queue(DEFAULT_SIZE, p.lockfree);
     Queue<optional<OutputType>> end_queue (DEFAULT_SIZE, p.lockfree);

--- a/include/ppi_thr/divideandconquer_thr.h
+++ b/include/ppi_thr/divideandconquer_thr.h
@@ -31,6 +31,8 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
  void internal_divide_and_conquer(parallel_execution_thr &p, Input &problem, Output &output,
                                         DivFunc &&divide, TaskFunc &&task, MergeFunc &&merge,
                                         std::atomic<int> &num_threads) {
+  // Sequential execution fo internal implementation
+  sequential_execution seq;
 
    if(num_threads.load()>0){
       auto subproblems = divide(problem);
@@ -63,7 +65,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
         }
 
         for(i; i != subproblems.end(); i++){
-              divide_and_conquer(sequential_execution {},*i,partials[division], std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
+              divide_and_conquer(seq,*i,partials[division], std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
         }
           //Main thread works on the first subproblem.
 
@@ -80,7 +82,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
         task(problem, output);
       }
     }else{
-        divide_and_conquer(sequential_execution {}, problem, output, std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
+        divide_and_conquer(seq, problem, output, std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
     }
 }
 
@@ -92,7 +94,10 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
  void divide_and_conquer(parallel_execution_thr& p, Input & problem, Output & output,
             DivFunc && divide, TaskFunc && task, MergeFunc && merge) {
-
+  
+    // Sequential execution fo internal implementation
+    sequential_execution seq;
+    
     std::atomic<int> num_threads (p.num_threads);
     
     if(num_threads.load()>0){
@@ -123,13 +128,13 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
             //END TRHEAD
         }
         for(i; i != subproblems.end(); i++){
-              divide_and_conquer(sequential_execution {},*i,partials[division], std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
+              divide_and_conquer(seq,*i,partials[division], std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
         }
           //Main thread works on the first subproblem.
         if(num_threads.load()>0){
             internal_divide_and_conquer(p, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge), num_threads);
         }else{
-            divide_and_conquer(sequential_execution {}, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
+            divide_and_conquer(seq, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
         }
 
           //JOIN
@@ -144,7 +149,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
         task(problem, output);
       }
     }else{
-        divide_and_conquer(sequential_execution {}, problem, output, std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
+        divide_and_conquer(seq, problem, output, std::forward<DivFunc>(divide), std::forward<TaskFunc>(task), std::forward<MergeFunc>(merge));
     }
 }
 

--- a/include/ppi_thr/divideandconquer_thr.h
+++ b/include/ppi_thr/divideandconquer_thr.h
@@ -90,7 +90,7 @@ template <typename Input, typename Output, typename DivFunc, typename TaskFunc, 
 
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
- void divide_and_conquer(parallel_execution_thr& p, Input & problem, Output & output,
+ void divide_and_conquer(parallel_execution_thr &p, Input & problem, Output & output,
             DivFunc const & divide, TaskFunc const & task, MergeFunc const & merge) {
 
     std::atomic<int> num_threads (p.num_threads);

--- a/include/ppi_thr/farm_thr.h
+++ b/include/ppi_thr/farm_thr.h
@@ -159,5 +159,6 @@ FarmObj<parallel_execution_thr,TaskFunc> farm(parallel_execution_thr &p, TaskFun
    
    return FarmObj<parallel_execution_thr, TaskFunc>(p, taskf);
 }
+
 }
 #endif

--- a/include/ppi_thr/farm_thr.h
+++ b/include/ppi_thr/farm_thr.h
@@ -155,7 +155,7 @@ template <typename GenFunc, typename TaskFunc>
 
 
 template <typename TaskFunc>
-FarmObj<parallel_execution_thr,TaskFunc> farm(parallel_execution_thr &p, TaskFunc && taskf){
+FarmObj<parallel_execution_thr,TaskFunc> farm(parallel_execution_thr& p, TaskFunc && taskf){
    
    return FarmObj<parallel_execution_thr, TaskFunc>(p, taskf);
 }

--- a/include/ppi_thr/farm_thr.h
+++ b/include/ppi_thr/farm_thr.h
@@ -155,7 +155,7 @@ template <typename GenFunc, typename TaskFunc>
 
 
 template <typename TaskFunc>
-FarmObj<parallel_execution_thr,TaskFunc> farm(parallel_execution_thr& p, TaskFunc && taskf){
+FarmObj<parallel_execution_thr,TaskFunc> farm(parallel_execution_thr &p, TaskFunc && taskf){
    
    return FarmObj<parallel_execution_thr, TaskFunc>(p, taskf);
 }

--- a/include/ppi_thr/map_thr.h
+++ b/include/ppi_thr/map_thr.h
@@ -24,7 +24,7 @@ using namespace std;
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>
- void map(parallel_execution_thr& p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc const & taskf){
+ void map(parallel_execution_thr &p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc const & taskf){
    
    std::vector<std::thread> tasks;
    int numElements = last - first; 
@@ -71,7 +71,7 @@ template <typename InputIt, typename OutputIt, typename TaskFunc>
 
 
 template <typename InputIt, typename OutputIt, typename ... MoreIn, typename TaskFunc>
- void map(parallel_execution_thr& p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs){
+ void map(parallel_execution_thr &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc const & taskf, MoreIn ... inputs){
  std::vector<std::thread> tasks;
    //Calculate number of elements per thread
    int numElements = last - first;

--- a/include/ppi_thr/mapreduce_thr.h
+++ b/include/ppi_thr/mapreduce_thr.h
@@ -25,7 +25,7 @@
 
 namespace grppi{
 template < typename InputIt, typename OutputIt, typename MapFunc, typename ReduceOperator,typename ... MoreIn >
- void map_reduce (parallel_execution_thr & p, InputIt first, InputIt last, OutputIt firstOut, MapFunc const & map, ReduceOperator op, MoreIn ... inputs) {
+ void map_reduce (parallel_execution_thr &p, InputIt first, InputIt last, OutputIt firstOut, MapFunc const & map, ReduceOperator op, MoreIn ... inputs) {
     // Register the thread in the execution model
     p.register_thread();
     while( first != last ) {
@@ -40,7 +40,7 @@ template < typename InputIt, typename OutputIt, typename MapFunc, typename Reduc
 
 
 template <typename InputIt, typename MapFunc, class T, typename ReduceOperator>
- T map_reduce ( parallel_execution_thr& p, InputIt first, InputIt last, MapFunc const &  map, T init, ReduceOperator op){
+ T map_reduce ( parallel_execution_thr &p, InputIt first, InputIt last, MapFunc const &  map, T init, ReduceOperator op){
     T out = init;
     std::vector<T> partialOuts(p.num_threads);
     std::vector<std::thread> tasks;

--- a/include/ppi_thr/pipeline_thr.h
+++ b/include/ppi_thr/pipeline_thr.h
@@ -77,7 +77,7 @@ template <typename InStream, typename Stage, typename OutStream>
 
 //Last stage
 template <typename Stream, typename Stage>
- void stages( parallel_execution_thr & p,Stream& st, Stage const& s ) {
+ void stages( parallel_execution_thr &p,Stream& st, Stage const& s ) {
 
    p.register_thread();
 
@@ -351,7 +351,7 @@ template <typename Stage, typename Stream,typename... Stages>
 //template <typename FuncIn,typename... Arguments>
 template <typename FuncIn, typename ...Stages,
           requires_no_arguments<FuncIn> = 0>
-void pipeline( parallel_execution_thr& p, FuncIn const & in, Stages ... sts ) {
+void pipeline( parallel_execution_thr &p, FuncIn const & in, Stages ... sts ) {
     //Create first queue
     Queue<std::pair< typename std::result_of<FuncIn()>::type, long>> q(DEFAULT_SIZE,p.lockfree);
     //Create stream generator stage

--- a/include/ppi_thr/reduce_thr.h
+++ b/include/ppi_thr/reduce_thr.h
@@ -29,7 +29,7 @@ namespace grppi{
 
 template < typename InputIt, typename Output, typename ReduceOperator>
  typename std::enable_if<!is_iterator<Output>::value, void>::type 
-reduce(parallel_execution_thr& p, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
+reduce(parallel_execution_thr &p, InputIt first, InputIt last, Output & firstOut, ReduceOperator op) {
 
     typename ReduceOperator::result_type identityVal = !op(false,true);
 

--- a/include/ppi_thr/stream_filter_thr.h
+++ b/include/ppi_thr/stream_filter_thr.h
@@ -142,7 +142,7 @@ template <typename GenFunc, typename FilterFunc, typename OutFunc>
 }
 
 template <typename FilterFunc>
-FilterObj<parallel_execution_thr, FilterFunc> stream_filter(parallel_execution_thr& p, FilterFunc && taskf){
+FilterObj<parallel_execution_thr, FilterFunc> stream_filter(parallel_execution_thr &p, FilterFunc && taskf){
    return FilterObj<parallel_execution_thr, FilterFunc>(p, taskf);
 
 }


### PR DESCRIPTION
Updated files from all implementations but ppi_thr.

The farm and stream filter objects do not allow to have const& in one of the templates.

