### PR TITLE
No using namespace in headers - Issue 57

### DIFF
--- a/include/ppi_omp/divideandconquer_omp.h
+++ b/include/ppi_omp/divideandconquer_omp.h
@@ -24,9 +24,9 @@
 #ifdef GRPPI_OMP
 
 #include <thread>
-namespace grppi
-{
-using namespace std;
+
+namespace grppi{
+
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
  void internal_divide_and_conquer(parallel_execution_omp p, Input & problem, Output & output,
             DivFunc && divide, TaskFunc && task, MergeFunc && merge, std::atomic<int> & num_threads) {

--- a/include/ppi_omp/farm_omp.h
+++ b/include/ppi_omp/farm_omp.h
@@ -25,7 +25,6 @@
 
 namespace grppi
 {
-using namespace std;
 
 template <typename GenFunc, typename TaskFunc>
 void farm(parallel_execution_omp p, GenFunc &&in, TaskFunc &&taskf) {

--- a/include/ppi_omp/map_omp.h
+++ b/include/ppi_omp/map_omp.h
@@ -23,7 +23,6 @@
 
 #ifdef GRPPI_OMP
 
-using namespace std;
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>

--- a/include/ppi_omp/pipeline_omp.h
+++ b/include/ppi_omp/pipeline_omp.h
@@ -25,7 +25,6 @@
 
 #include <boost/lockfree/spsc_queue.hpp>
 
-using namespace std;
 namespace grppi{
 //Last stage
 template <typename Stream, typename Stage>

--- a/include/ppi_omp/reduce_omp.h
+++ b/include/ppi_omp/reduce_omp.h
@@ -25,7 +25,6 @@
 
 #include <thread>
 
-using namespace std;
 namespace grppi{
 //typename std::enable_if<!is_iterator<Output>::value, bool>::type,
 

--- a/include/ppi_omp/stencil_omp.h
+++ b/include/ppi_omp/stencil_omp.h
@@ -23,7 +23,6 @@
 
 #ifdef GRPPI_OMP
 
-using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
  void stencil(parallel_execution_omp p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {

--- a/include/ppi_omp/stream_filter_omp.h
+++ b/include/ppi_omp/stream_filter_omp.h
@@ -23,7 +23,6 @@
 
 #ifdef GRPPI_OMP
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
  void stream_filter(parallel_execution_omp p, GenFunc && in, FilterFunc && filter, OutFunc && out ) {

--- a/include/ppi_omp/stream_reduce_omp.h
+++ b/include/ppi_omp/stream_reduce_omp.h
@@ -26,7 +26,6 @@
 
 #include "../reduce.h"
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
  void stream_reduce(parallel_execution_omp p, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red, OutputType &reduce_value ){

--- a/include/ppi_seq/divideandconquer_seq.h
+++ b/include/ppi_seq/divideandconquer_seq.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_DIVIDEANDCONQUER_SEQ_H
 #define GRPPI_DIVIDEANDCONQUER_SEQ_H
 namespace grppi{
-using namespace std;
 
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
  void divide_and_conquer(sequential_execution s, Input &problem, Output &output, DivFunc &&divide,

--- a/include/ppi_seq/farm_seq.h
+++ b/include/ppi_seq/farm_seq.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_FARM_SEQ_H
 #define GRPPI_FARM_SEQ_H
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc>
 void farm(sequential_execution , GenFunc &&in, TaskFunc && taskf ) {

--- a/include/ppi_seq/map_seq.h
+++ b/include/ppi_seq/map_seq.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_MAP_SEQ_H
 #define GRPPI_MAP_SEQ_H
 
-using namespace std;
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>

--- a/include/ppi_seq/pipeline_seq.h
+++ b/include/ppi_seq/pipeline_seq.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_PIPELINE_SEQ_H
 #define GRPPI_PIPELINE_SEQ_H
 
-using namespace std;
 namespace grppi {
 
 template <typename InType, int currentStage, typename ...Stages>

--- a/include/ppi_seq/reduce_seq.h
+++ b/include/ppi_seq/reduce_seq.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_REDUCE_SEQ_H
 #define GRPPI_REDUCE_SEQ_H
 
-using namespace std;
 namespace grppi{
 //typename std::enable_if<!is_iterator<Output>::value, bool>::type,
 

--- a/include/ppi_seq/stencil_seq.h
+++ b/include/ppi_seq/stencil_seq.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_STENCIL_SEQ_H
 #define GRPPI_STENCIL_SEQ_H
 
-using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
  void stencil(sequential_execution s, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {

--- a/include/ppi_seq/stream_filter_seq.h
+++ b/include/ppi_seq/stream_filter_seq.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_STREAM_FILTER_SEQ_H
 #define GRPPI_STREAM_FILTER_SEQ_H
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
 void stream_filter(sequential_execution, GenFunc && in, FilterFunc && filter, OutFunc && out ) {

--- a/include/ppi_seq/stream_reduce_seq.hpp
+++ b/include/ppi_seq/stream_reduce_seq.hpp
@@ -24,7 +24,6 @@
 #include "../reduce.h"
 #include <vector>
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
  void stream_reduce(sequential_execution s, GenFunc &&in, TaskFunc && taskf, ReduceFunc &&red, OutputType &reduce_value ) {

--- a/include/ppi_tbb/divideandconquer_tbb.h
+++ b/include/ppi_tbb/divideandconquer_tbb.h
@@ -25,7 +25,6 @@
 
 #include <tbb/tbb.h>
 namespace grppi{
-using namespace std;
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
  void internal_divide_and_conquer(parallel_execution_tbb p, Input & problem, Output & output,
             DivFunc && divide, TaskFunc && task, MergeFunc && merge, std::atomic<int>& num_threads) {

--- a/include/ppi_tbb/map_tbb.h
+++ b/include/ppi_tbb/map_tbb.h
@@ -25,7 +25,7 @@
 
 #include <tbb/tbb.h>
 namespace grppi{
-using namespace std;
+
 template <typename InputIt, typename OutputIt, typename TaskFunc>
 void map(parallel_execution_tbb p, InputIt first,InputIt last, OutputIt firstOut, TaskFunc && taskf){
    tbb::parallel_for(static_cast<std::size_t>(0),static_cast<std::size_t>( (last-first) ), [&] (std::size_t index){

--- a/include/ppi_tbb/pipeline_tbb.h
+++ b/include/ppi_tbb/pipeline_tbb.h
@@ -26,7 +26,6 @@
 #include <tbb/pipeline.h>
 #include <tbb/tbb.h>
 
-using namespace std;
 namespace grppi{
 //Last stage
 template <typename Stream, typename Stage>

--- a/include/ppi_tbb/reduce_tbb.h
+++ b/include/ppi_tbb/reduce_tbb.h
@@ -25,8 +25,6 @@
 
 #include <tbb/tbb.h>
 
-using namespace std;
-
 //typename std::enable_if<!is_iterator<Output>::value, bool>::type,
 namespace grppi{
 template < typename InputIt, typename Output,typename ReduceOperator>

--- a/include/ppi_tbb/stencil_tbb.h
+++ b/include/ppi_tbb/stencil_tbb.h
@@ -24,7 +24,7 @@
 #ifdef GRPPI_TBB
 
 #include <tbb/tbb.h>
-using namespace std;
+
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
  void stencil(parallel_execution_tbb p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {

--- a/include/ppi_tbb/stream_filter_tbb.h
+++ b/include/ppi_tbb/stream_filter_tbb.h
@@ -24,7 +24,7 @@
 #ifdef GRPPI_TBB
 
 #include <tbb/tbb.h>
-using namespace std;
+
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
  void stream_filter(parallel_execution_tbb p, GenFunc && in, FilterFunc && filter, OutFunc && out ) {

--- a/include/ppi_tbb/stream_reduce_tbb.h
+++ b/include/ppi_tbb/stream_reduce_tbb.h
@@ -26,7 +26,6 @@
 #include "../reduce.h"
 #include <tbb/tbb.h>
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
  void stream_reduce(parallel_execution_tbb p, GenFunc &&in, TaskFunc &&taskf, ReduceFunc &&red, OutputType &reduce_value ){

--- a/include/ppi_thr/divideandconquer_thr.h
+++ b/include/ppi_thr/divideandconquer_thr.h
@@ -24,8 +24,6 @@
 #include <thread>
 #include <atomic>
 
-
-using namespace std;
 namespace grppi{
 template <typename Input, typename Output, typename DivFunc, typename TaskFunc, typename MergeFunc>
  void internal_divide_and_conquer(parallel_execution_thr &p, Input &problem, Output &output,

--- a/include/ppi_thr/farm_thr.h
+++ b/include/ppi_thr/farm_thr.h
@@ -25,7 +25,7 @@
 #include <thread>
 #include <utility>
 #include <memory>
-using namespace std;
+
 namespace grppi{
 
 template <typename GenFunc, typename TaskFunc, typename SinkFunc>

--- a/include/ppi_thr/map_thr.h
+++ b/include/ppi_thr/map_thr.h
@@ -20,7 +20,7 @@
 
 #ifndef GRPPI_MAP_THR_H
 #define GRPPI_MAP_THR_H
-using namespace std;
+
 namespace grppi{
 
 template <typename InputIt, typename OutputIt, typename TaskFunc>

--- a/include/ppi_thr/mapreduce_thr.h
+++ b/include/ppi_thr/mapreduce_thr.h
@@ -41,6 +41,7 @@ template < typename InputIt, typename OutputIt, typename MapFunc, typename Reduc
 
 template <typename InputIt, typename MapFunc, class T, typename ReduceOperator>
  T map_reduce ( parallel_execution_thr& p, InputIt first, InputIt last, MapFunc &&  map, T init, ReduceOperator op){
+  using namespace std;
     T out = init;
     std::vector<T> partialOuts(p.num_threads);
     std::vector<std::thread> tasks;

--- a/include/ppi_thr/mapreduce_thr.h
+++ b/include/ppi_thr/mapreduce_thr.h
@@ -41,7 +41,9 @@ template < typename InputIt, typename OutputIt, typename MapFunc, typename Reduc
 
 template <typename InputIt, typename MapFunc, class T, typename ReduceOperator>
  T map_reduce ( parallel_execution_thr& p, InputIt first, InputIt last, MapFunc &&  map, T init, ReduceOperator op){
-  using namespace std;
+
+    using namespace std;
+    
     T out = init;
     std::vector<T> partialOuts(p.num_threads);
     std::vector<std::thread> tasks;

--- a/include/ppi_thr/pipeline_thr.h
+++ b/include/ppi_thr/pipeline_thr.h
@@ -23,7 +23,6 @@
 
 #include <thread>
 
-using namespace std;
 namespace grppi{
 
 template <typename InStream, typename OutStream, int currentStage, typename ...Stages>

--- a/include/ppi_thr/reduce_thr.h
+++ b/include/ppi_thr/reduce_thr.h
@@ -23,7 +23,7 @@
 
 #include <thread>
 #include <functional>
-using namespace std;
+
 namespace grppi{
 //typename std::enable_if<!is_iterator<Output>::value, bool>::type,
 

--- a/include/ppi_thr/stencil_thr.h
+++ b/include/ppi_thr/stencil_thr.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_STENCIL_THR_H
 #define GRPPI_STENCIL_THR_H
 
-using namespace std;
 namespace grppi{
 template <typename InputIt, typename OutputIt, typename TaskFunc, typename NFunc>
  void stencil(parallel_execution_thr &p, InputIt first, InputIt last, OutputIt firstOut, TaskFunc && taskf, NFunc && neighbor ) {

--- a/include/ppi_thr/stream_filter_thr.h
+++ b/include/ppi_thr/stream_filter_thr.h
@@ -21,7 +21,6 @@
 #ifndef GRPPI_STREAM_FILTER_THR_H
 #define GRPPI_STREAM_FILTER_THR_H
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename FilterFunc, typename OutFunc>
  void stream_filter(parallel_execution_thr &p, GenFunc && in, FilterFunc && filter, OutFunc && out ) {

--- a/include/ppi_thr/stream_iteration_thr.h
+++ b/include/ppi_thr/stream_iteration_thr.h
@@ -25,8 +25,6 @@
 #include <utility>
 #include <memory>
 
-
-
 namespace grppi{ 
 
 template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Stages>

--- a/include/ppi_thr/stream_reduce_thr.h
+++ b/include/ppi_thr/stream_reduce_thr.h
@@ -25,7 +25,6 @@
 
 #include <thread>
 
-using namespace std;
 namespace grppi{
 template <typename GenFunc, typename TaskFunc, typename ReduceFunc, typename OutputType>
  void stream_reduce(parallel_execution_thr &p, GenFunc &&in, TaskFunc &&taskf, ReduceFunc &&red, OutputType &reduce_value ){

--- a/legacy_utest/stream_reduce_example_GT.cpp
+++ b/legacy_utest/stream_reduce_example_GT.cpp
@@ -28,6 +28,7 @@
 using namespace grppi;
 
 std::vector<int> read_list(std::istream & is){
+  using namespace std;
   std::vector<int> result;
   string line;
   is >> ws;
@@ -43,6 +44,7 @@ std::vector<int> read_list(std::istream & is){
 
 
 int stream_reduce_example(auto &p) {
+    using namespace std;
  
 #ifndef NTHREADS
 #define NTHREADS 6

--- a/samples/util/util.h
+++ b/samples/util/util.h
@@ -35,7 +35,7 @@ grppi::polymorphic_execution execution_mode(const std::string & opt) {
 }
 
 template <typename F, typename ...Args>
-bool run_test(const string & mode, F && f, Args && ... args) {
+bool run_test(const std::string & mode, F && f, Args && ... args) {
   auto e = execution_mode(mode);
   if (e.has_execution()) {
     f(e, std::forward<Args>(args)...);

--- a/tests/mapreduce1.cpp
+++ b/tests/mapreduce1.cpp
@@ -27,6 +27,7 @@ using namespace std;
 using namespace grppi;
 
 void mapreduce_example1() {
+  using namespace std;
 
 #ifndef NTHREADS
 #define NTHREADS 6

--- a/tests/stream_reduce_example.cpp
+++ b/tests/stream_reduce_example.cpp
@@ -27,6 +27,7 @@
 using namespace grppi;
 
 std::vector<int> read_list(std::istream & is){
+  using namespace std;
   std::vector<int> result;
   string line;
   is >> ws;
@@ -42,7 +43,7 @@ std::vector<int> read_list(std::istream & is){
 
 
 void stream_reduce_example() {
- 
+ using namespace std;
 #ifndef NTHREADS
 #define NTHREADS 6
 #endif


### PR DESCRIPTION
Removed "using namespace std" from the headers.

If a function requires it, set "using namespace" in the scope of the function.