### PR TITLE
Rename pattern objects - issue 18

### DIFF
--- a/include/common/patterns.h
+++ b/include/common/patterns.h
@@ -25,43 +25,43 @@
 namespace grppi{
 
 template <typename E,typename Stage, typename ... Stages>
-class PipelineObj{
+class pipeline_info{
    public:
       E * exectype;
       std::tuple<Stage *, Stages *...> stages;
-      PipelineObj(E &p, Stage s, Stages ... sts):stages(std::make_tuple(&s, &sts...)) { exectype = &p;}
+      pipeline_info(E &p, Stage s, Stages ... sts):stages(std::make_tuple(&s, &sts...)) { exectype = &p;}
 };
 
 template <typename E,class Operation, class RedFunc>
-class ReduceObj
+class reduction_info
 {
    public:
       Operation * task;
       RedFunc * red;
       E exectype;
-      ReduceObj(E s, Operation farm, RedFunc r){exectype=s; task = &farm; red= &r;}
+      reduction_info(E s, Operation farm, RedFunc r){exectype=s; task = &farm; red= &r;}
 };
 
 template <typename E,class Operation>
-class FarmObj
+class farm_info
 {
    public:
       Operation * task;
       E * exectype;
       int farmtype;
-      FarmObj(E &s,Operation f){exectype=&s; task = &f;};
+      farm_info(E &s,Operation f){exectype=&s; task = &f;};
 
 
 };
 
 template <typename E,class Operation>
-class FilterObj
+class filter_info
 {
    public:
       Operation * task;
       E *exectype;
       int filtertype;
-      FilterObj(E& s,Operation f){exectype=&s; task = &f;};
+      filter_info(E& s,Operation f){exectype=&s; task = &f;};
 };
 
 } // end namespace grppi

--- a/include/ppi_omp/farm_omp.h
+++ b/include/ppi_omp/farm_omp.h
@@ -64,8 +64,8 @@ void farm(parallel_execution_omp &p, GenFunc &&in, Operation &&op) {
 }
 
 template <typename Operation>
-FarmObj<parallel_execution_omp,Operation> farm(parallel_execution_omp &p, Operation && op){
-   return FarmObj<parallel_execution_omp, Operation>(p,op);
+farm_info<parallel_execution_omp,Operation> farm(parallel_execution_omp &p, Operation && op){
+   return farm_info<parallel_execution_omp, Operation>(p,op);
 }
 }
 #endif

--- a/include/ppi_omp/pipeline_omp.h
+++ b/include/ppi_omp/pipeline_omp.h
@@ -74,7 +74,7 @@ void stages( parallel_execution_omp &p, Stream& st, Stage && s ){
 }
 
 template <typename Operation, typename Stream,typename... Stages>
- void stages( parallel_execution_omp &p, Stream& st, FilterObj<parallel_execution_omp, Operation>& se, Stages && ... sgs ) {
+ void stages( parallel_execution_omp &p, Stream& st, filter_info<parallel_execution_omp, Operation>& se, Stages && ... sgs ) {
     if(p.ordering){
        Queue< typename Stream::value_type > q(DEFAULT_SIZE);
 
@@ -185,7 +185,7 @@ template <typename Operation, typename Stream,typename... Stages>
 
 
 template <typename Operation, typename Stream,typename... Stages>
- void stages( parallel_execution_omp &p, Stream& st, FarmObj<parallel_execution_omp, Operation> se, Stages && ... sgs ) {
+ void stages( parallel_execution_omp &p, Stream& st, farm_info<parallel_execution_omp, Operation> se, Stages && ... sgs ) {
    
     Queue< std::pair < optional < typename std::result_of< Operation(typename Stream::value_type::first_type::value_type) >::type >, long > > q(DEFAULT_SIZE);
     std::atomic<int> nend ( 0 );

--- a/include/ppi_omp/stream_filter_omp.h
+++ b/include/ppi_omp/stream_filter_omp.h
@@ -87,8 +87,8 @@ template <typename GenFunc, typename FilterFunc, typename OutFunc>
 }
 
 template <typename FilterFunc>
-FilterObj<parallel_execution_omp, FilterFunc> stream_filter(parallel_execution_omp &p, FilterFunc && op){
-   return FilterObj<parallel_execution_omp, FilterFunc>(p, op);
+filter_info<parallel_execution_omp, FilterFunc> stream_filter(parallel_execution_omp &p, FilterFunc && op){
+   return filter_info<parallel_execution_omp, FilterFunc>(p, op);
 
 }
 }

--- a/include/ppi_omp/stream_reduce_omp.h
+++ b/include/ppi_omp/stream_reduce_omp.h
@@ -114,8 +114,8 @@ template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
 
 
 template <typename Operation, typename RedFunc>
-ReduceObj<parallel_execution_omp,Operation, RedFunc> stream_reduce(parallel_execution_omp &p, Operation && op, RedFunc && red){
-   return ReduceObj<parallel_execution_omp, Operation, RedFunc>(p,op, red);
+reduction_info<parallel_execution_omp,Operation, RedFunc> stream_reduce(parallel_execution_omp &p, Operation && op, RedFunc && red){
+   return reduction_info<parallel_execution_omp, Operation, RedFunc>(p,op, red);
 }
 }
 #endif

--- a/include/ppi_seq/farm_seq.h
+++ b/include/ppi_seq/farm_seq.h
@@ -47,8 +47,8 @@ void farm(sequential_execution , GenFunc &&in, Operation && op, SinkFunc &&sink 
 
 
 template <typename Operation>
-FarmObj<sequential_execution,Operation> farm(sequential_execution &s, Operation && op){
-   return FarmObj<sequential_execution, Operation>(s ,op);
+farm_info<sequential_execution,Operation> farm(sequential_execution &s, Operation && op){
+   return farm_info<sequential_execution, Operation>(s ,op);
 }
 }
 #endif

--- a/include/ppi_seq/pipeline_seq.h
+++ b/include/ppi_seq/pipeline_seq.h
@@ -24,14 +24,14 @@
 namespace grppi {
 
 template <typename InType, int currentStage, typename ...Stages>
- typename std::enable_if<(currentStage == (sizeof...(Stages)-1)), InType>::type composed_pipeline(InType in, PipelineObj<sequential_execution, Stages...> const & pipe)
+ typename std::enable_if<(currentStage == (sizeof...(Stages)-1)), InType>::type composed_pipeline(InType in, pipeline_info<sequential_execution, Stages...> const & pipe)
 {
      return (*std::get<currentStage>(pipe.stages))(in);
 }
 
 
 template <typename InType, int currentStage, typename ...Stages>
- typename std::enable_if<(currentStage < (sizeof...(Stages)-1)), InType>::type composed_pipeline(InType in, PipelineObj<sequential_execution, Stages...> const & pipe)
+ typename std::enable_if<(currentStage < (sizeof...(Stages)-1)), InType>::type composed_pipeline(InType in, pipeline_info<sequential_execution, Stages...> const & pipe)
 {
      auto val = (*std::get<currentStage>(pipe.stages))(in);
      return composed_pipeline<InType, currentStage+1, Stages...>(val,pipe);
@@ -47,7 +47,7 @@ void stages(sequential_execution &s, Stream st, Stage && se ) {
 
 //Filter stage
 template <typename task, typename Stream, typename... Stages>
-void stages(sequential_execution &s, Stream st, FilterObj<sequential_execution, task> && se, Stages && ... sgs ) {
+void stages(sequential_execution &s, Stream st, filter_info<sequential_execution, task> && se, Stages && ... sgs ) {
 
 //   auto out = se.run(st);
      if((*se.task)(st))

--- a/include/ppi_seq/stream_filter_seq.h
+++ b/include/ppi_seq/stream_filter_seq.h
@@ -48,8 +48,8 @@ void stream_filter( GenFunc && in, FilterFunc && filter, OutFunc && out ) {
 }
 
 template <typename FilterFunc>
-FilterObj<sequential_execution, FilterFunc> stream_filter(sequential_execution &s, FilterFunc && op){
-   return FilterObj<sequential_execution, FilterFunc>(s, op);
+filter_info<sequential_execution, FilterFunc> stream_filter(sequential_execution &s, FilterFunc && op){
+   return filter_info<sequential_execution, FilterFunc>(s, op);
 }
 
 }

--- a/include/ppi_seq/stream_iteration_seq.h
+++ b/include/ppi_seq/stream_iteration_seq.h
@@ -36,7 +36,7 @@ template<typename GenFunc, typename Operation, typename Predicate, typename OutF
 }
 
 template<typename GenFunc, typename Operation, typename Predicate, typename OutFunc>
- void stream_iteration(sequential_execution, GenFunc && in, FarmObj<sequential_execution, Operation> && f, Predicate && condition, OutFunc && out){
+ void stream_iteration(sequential_execution, GenFunc && in, farm_info<sequential_execution, Operation> && f, Predicate && condition, OutFunc && out){
    while(1){
        auto k = in();       
        if(!k) break;
@@ -49,7 +49,7 @@ template<typename GenFunc, typename Operation, typename Predicate, typename OutF
 }
 
 template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Stages>
- void stream_iteration(sequential_execution &s, GenFunc && in, PipelineObj<sequential_execution, Stages...> && f, Predicate && condition, OutFunc && out){
+ void stream_iteration(sequential_execution &s, GenFunc && in, pipeline_info<sequential_execution, Stages...> && f, Predicate && condition, OutFunc && out){
    while(1){
        auto k = in();
        if(!k) break; 

--- a/include/ppi_tbb/farm_tbb.h
+++ b/include/ppi_tbb/farm_tbb.h
@@ -122,8 +122,8 @@ template <typename GenFunc, typename Operation>
 
 
 template <typename Operation>
-FarmObj<parallel_execution_tbb,Operation> farm(parallel_execution_tbb &p, Operation && op){
-   return FarmObj<parallel_execution_tbb, Operation>(p,op);
+farm_info<parallel_execution_tbb,Operation> farm(parallel_execution_tbb &p, Operation && op){
+   return farm_info<parallel_execution_tbb, Operation>(p,op);
 }
 }
 #endif

--- a/include/ppi_tbb/stream_filter_tbb.h
+++ b/include/ppi_tbb/stream_filter_tbb.h
@@ -128,8 +128,8 @@ template <typename GenFunc, typename FilterFunc, typename OutFunc>
 }
 
 template <typename FilterFunc>
-FilterObj<parallel_execution_tbb, FilterFunc> stream_filter(parallel_execution_tbb &p, FilterFunc && op){
-   return FilterObj<parallel_execution_tbb, FilterFunc>(p, op);
+filter_info<parallel_execution_tbb, FilterFunc> stream_filter(parallel_execution_tbb &p, FilterFunc && op){
+   return filter_info<parallel_execution_tbb, FilterFunc>(p, op);
 
 }
 }

--- a/include/ppi_tbb/stream_reduce_tbb.h
+++ b/include/ppi_tbb/stream_reduce_tbb.h
@@ -108,8 +108,8 @@ template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
 }
 
 template <typename Operation, typename RedFunc>
-ReduceObj<parallel_execution_tbb,Operation, RedFunc> stream_reduce(parallel_execution_thr &p, Operation && op, RedFunc && red){
-   return ReduceObj<parallel_execution_tbb, Operation, RedFunc>(p,op, red);
+reduction_info<parallel_execution_tbb,Operation, RedFunc> stream_reduce(parallel_execution_thr &p, Operation && op, RedFunc && red){
+   return reduction_info<parallel_execution_tbb, Operation, RedFunc>(p,op, red);
 }
 }
 #endif

--- a/include/ppi_thr/farm_thr.h
+++ b/include/ppi_thr/farm_thr.h
@@ -155,9 +155,9 @@ template <typename GenFunc, typename Operation>
 
 
 template <typename Operation>
-FarmObj<parallel_execution_thr,Operation> farm(parallel_execution_thr &p, Operation && op){
+farm_info<parallel_execution_thr,Operation> farm(parallel_execution_thr &p, Operation && op){
    
-   return FarmObj<parallel_execution_thr, Operation>(p, op);
+   return farm_info<parallel_execution_thr, Operation>(p, op);
 }
 
 }

--- a/include/ppi_thr/stream_filter_thr.h
+++ b/include/ppi_thr/stream_filter_thr.h
@@ -141,8 +141,8 @@ template <typename GenFunc, typename FilterFunc, typename OutFunc>
 }
 
 template <typename FilterFunc>
-FilterObj<parallel_execution_thr, FilterFunc> stream_filter(parallel_execution_thr &p, FilterFunc && op){
-   return FilterObj<parallel_execution_thr, FilterFunc>(p, op);
+filter_info<parallel_execution_thr, FilterFunc> stream_filter(parallel_execution_thr &p, FilterFunc && op){
+   return filter_info<parallel_execution_thr, FilterFunc>(p, op);
 
 }
 }

--- a/include/ppi_thr/stream_iteration_thr.h
+++ b/include/ppi_thr/stream_iteration_thr.h
@@ -28,7 +28,7 @@
 namespace grppi{ 
 
 template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Stages>
- void stream_iteration(parallel_execution_thr &p, GenFunc && in, PipelineObj<parallel_execution_thr , Stages...> && se, Predicate && condition, OutFunc && out){
+ void stream_iteration(parallel_execution_thr &p, GenFunc && in, pipeline_info<parallel_execution_thr , Stages...> && se, Predicate && condition, OutFunc && out){
    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.lockfree);
    Queue< typename std::result_of<GenFunc()>::type > queueOut(DEFAULT_SIZE,p.lockfree);
    std::atomic<int> nend (0);
@@ -78,7 +78,7 @@ template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Sta
 }
 
 template<typename GenFunc, typename Operation, typename Predicate, typename OutFunc>
- void stream_iteration(parallel_execution_thr &p, GenFunc && in, FarmObj<parallel_execution_thr,Operation> && se, Predicate && condition, OutFunc && out){
+ void stream_iteration(parallel_execution_thr &p, GenFunc && in, farm_info<parallel_execution_thr,Operation> && se, Predicate && condition, OutFunc && out){
    std::vector<std::thread> tasks;
    Queue< typename std::result_of<GenFunc()>::type > queue(DEFAULT_SIZE,p.lockfree);
    Queue< typename std::result_of<GenFunc()>::type > queueOut(DEFAULT_SIZE,p.lockfree);

--- a/include/ppi_thr/stream_reduce_thr.h
+++ b/include/ppi_thr/stream_reduce_thr.h
@@ -119,8 +119,8 @@ template <typename GenFunc, typename ReduceOperator, typename SinkFunc>
 
 
 template <typename Operation, typename RedFunc>
-ReduceObj<parallel_execution_thr,Operation, RedFunc> stream_reduce(parallel_execution_thr p, Operation && op, RedFunc && red){
-   return ReduceObj<parallel_execution_thr, Operation, RedFunc>(p,op, red);
+reduction_info<parallel_execution_thr,Operation, RedFunc> stream_reduce(parallel_execution_thr p, Operation && op, RedFunc && red){
+   return reduction_info<parallel_execution_thr, Operation, RedFunc>(p,op, red);
 }
 }
 #endif


### PR DESCRIPTION
Renamed pattern objects.

PipelineObj -> pipeline_info
ReduceObj -> reduction_info
FarmObj -> farm_info
FilterObjt -> filter_info