### PR TITLE
mpmc_queue modified - issue-114

### DIFF
--- a/include/common/common.h
+++ b/include/common/common.h
@@ -22,7 +22,6 @@
 #define GRPPI_COMMON_H
 
 // Includes for execution policies
-#include "queue_modes.h"
 #include "sequential_execution.h"
 #include "parallel_execution_native.h"
 #include "parallel_execution_omp.h"
@@ -30,7 +29,6 @@
 
 // Includes with GRPPI internals
 #include "optional.h"
-#include "mpmc_queue.h"
 #include "callable_traits.h"
 #include "iterator.h"
 #include "patterns.h"

--- a/include/common/common.h
+++ b/include/common/common.h
@@ -22,6 +22,7 @@
 #define GRPPI_COMMON_H
 
 // Includes for execution policies
+#include "queue_modes.h"
 #include "sequential_execution.h"
 #include "parallel_execution_native.h"
 #include "parallel_execution_omp.h"

--- a/include/common/mpmc_queue.h
+++ b/include/common/mpmc_queue.h
@@ -18,6 +18,10 @@
 * See COPYRIGHT.txt for copyright notices and details.
 */
 
+#ifndef GRPPI_MPMC_QUEUE_H
+#define GRPPI_MPMC_QUEUE_H
+
+
 #include <vector>
 #include <atomic>
 #include <iostream>
@@ -28,14 +32,14 @@ namespace grppi{
 
 constexpr int DEFAULT_SIZE = 100;
 
-
+enum class queue_mode {lockfree = true, blocking = false};
 
 template <typename T>
 class mpmc_queue{
    private:
       int size;
       std::vector<T> buffer;
-      Queue_mode lockfree = Queue_mode::blocking;
+      queue_mode mode;
 
       std::atomic<unsigned long long> pread;
       std::atomic<unsigned long long> pwrite;
@@ -55,8 +59,8 @@ class mpmc_queue{
       bool push(T item);
       bool empty();
       
-      mpmc_queue<T>(int _size, Queue_mode active = Queue_mode::blocking ):
-           size{_size}, buffer{std::vector<T>(size)}, lockfree{active}, pread{0}, pwrite{0}, internal_pread{0}, internal_pwrite{0} { }
+      mpmc_queue<T>(int _size, queue_mode active = queue_mode::blocking ):
+           size{_size}, buffer{std::vector<T>(size)}, mode{active}, pread{0}, pwrite{0}, internal_pread{0}, internal_pwrite{0} { }
 
 };
 
@@ -81,7 +85,7 @@ bool mpmc_queue<T>::full(unsigned long long current){
 }
 template <typename T>
 T mpmc_queue<T>::pop(){
-  if(lockfree == Queue_mode::lockfree){
+  if(mode == queue_mode::lockfree){
     
      unsigned long long current;
 
@@ -116,7 +120,7 @@ T mpmc_queue<T>::pop(){
 
 template <typename T>
 bool mpmc_queue<T>::push(T item){
-  if(lockfree == Queue_mode::lockfree){
+  if(mode == queue_mode::lockfree){
 
      unsigned long long current;
      do{
@@ -151,3 +155,5 @@ bool mpmc_queue<T>::push(T item){
 }
 
 }
+
+#endif

--- a/include/common/parallel_execution_native.h
+++ b/include/common/parallel_execution_native.h
@@ -40,7 +40,7 @@ struct parallel_execution_native {
   thread_pool pool;
   bool ordering = true;
   int num_threads = 4;
-  bool lockfree = false;
+  Queue_mode lockfree = Queue_mode::blocking;
 
   int get_threadID(){
       while (lock.test_and_set(std::memory_order_acquire));

--- a/include/common/parallel_execution_native.h
+++ b/include/common/parallel_execution_native.h
@@ -28,6 +28,7 @@
 #include <type_traits>
 
 #include "native/pool.h"
+#include "mpmc_queue.h"
 
 namespace grppi {
 
@@ -40,7 +41,7 @@ struct parallel_execution_native {
   thread_pool pool;
   bool ordering = true;
   int num_threads = 4;
-  Queue_mode lockfree = Queue_mode::blocking;
+  queue_mode lockfree = queue_mode::blocking;
 
   int get_threadID(){
       while (lock.test_and_set(std::memory_order_acquire));

--- a/include/common/parallel_execution_omp.h
+++ b/include/common/parallel_execution_omp.h
@@ -35,7 +35,7 @@ namespace grppi{
  */
 struct parallel_execution_omp{
   bool ordering = true;
-  bool lockfree = false;
+  Queue_mode lockfree = Queue_mode::blocking;
   int num_threads = 4;
   int get_threadID(){
      return omp_get_thread_num();

--- a/include/common/parallel_execution_omp.h
+++ b/include/common/parallel_execution_omp.h
@@ -28,6 +28,8 @@
 
 #include <omp.h>
 
+#include "mpmc_queue.h"
+
 namespace grppi{
 
 /** @brief Set the execution mode to parallel with ompenmp framework 
@@ -35,7 +37,7 @@ namespace grppi{
  */
 struct parallel_execution_omp{
   bool ordering = true;
-  Queue_mode lockfree = Queue_mode::blocking;
+  queue_mode lockfree = queue_mode::blocking;
   int num_threads = 4;
   int get_threadID(){
      return omp_get_thread_num();

--- a/include/common/parallel_execution_tbb.h
+++ b/include/common/parallel_execution_tbb.h
@@ -33,7 +33,7 @@ namespace grppi{
  */
 struct parallel_execution_tbb{
   bool ordering = true;
-  bool lockfree = false;
+  Queue_mode lockfree = Queue_mode::blocking;
   int num_threads = 4;
   int num_tokens = 100;
   /** @brief Set num_threads to the maximum number of thread available by the

--- a/include/common/parallel_execution_tbb.h
+++ b/include/common/parallel_execution_tbb.h
@@ -26,6 +26,8 @@
 
 #include <type_traits>
 
+#include "mpmc_queue.h"
+
 namespace grppi{
 
 /** @brief Set the execution mode to parallel with threading building blocks
@@ -33,7 +35,7 @@ namespace grppi{
  */
 struct parallel_execution_tbb{
   bool ordering = true;
-  Queue_mode lockfree = Queue_mode::blocking;
+  queue_mode lockfree = queue_mode::blocking;
   int num_threads = 4;
   int num_tokens = 100;
   /** @brief Set num_threads to the maximum number of thread available by the

--- a/include/common/queue_modes.h
+++ b/include/common/queue_modes.h
@@ -1,6 +1,0 @@
-namespace grppi{
-
-   enum class Queue_mode {lockfree = true, blocking = false};
-
-}
-

--- a/include/common/queue_modes.h
+++ b/include/common/queue_modes.h
@@ -1,0 +1,6 @@
+namespace grppi{
+
+   enum class Queue_mode {lockfree = true, blocking = false};
+
+}
+


### PR DESCRIPTION
Changes:
- A file with the enum class Queue_modes has been introduced.
- Instead of using a boolean, the queue mode is defined by the aforementioned enum class.
- The constructor with a single parameter has been deleted. 
- Now there is only one contructor with a default value for the second parameter.
- The data members initializations is performed in the initialization list of the constructor.
- The data member that defines the queue mode in the execution models has been modified from bolean type to Queue_mode.