### PR TITLE
Function objects pased as forwarding reference - issue-124

### DIFF
--- a/include/native/farm.h
+++ b/include/native/farm.h
@@ -29,11 +29,9 @@
 namespace grppi{
 
 template <typename GenFunc, typename Operation, typename SinkFunc>
- void farm(parallel_execution_native &p, GenFunc &&in, Operation && op , SinkFunc &&sink) {
+void farm(parallel_execution_native &p, GenFunc &&in, Operation && op , SinkFunc &&sink) {
 
     std::vector<std::thread> tasks;
-//    mpmc_queue< typename std::result_of<GenFunc()>::type > queue(p.queue_size);
-//    mpmc_queue< optional < typename std::result_of<Operation(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(p.queue_size);
     mpmc_queue< typename std::result_of<GenFunc()>::type > queue (p.queue_size,p.lockfree);
     mpmc_queue< optional < typename std::result_of<Operation(typename std::result_of<GenFunc()>::type::value_type)>::type > > queueout(p.queue_size, p.lockfree);
     std::atomic<int> nend(0);
@@ -157,7 +155,7 @@ template <typename GenFunc, typename Operation>
 template <typename Operation>
 farm_info<parallel_execution_native,Operation> farm(parallel_execution_native &p, Operation && op){
    
-   return farm_info<parallel_execution_native, Operation>(p, op);
+   return farm_info<parallel_execution_native, Operation>(p, std::forward<Operation>(op) );
 }
 
 }

--- a/include/omp/farm.h
+++ b/include/omp/farm.h
@@ -65,7 +65,7 @@ void farm(parallel_execution_omp &p, GenFunc &&in, Operation &&op) {
 
 template <typename Operation>
 farm_info<parallel_execution_omp,Operation> farm(parallel_execution_omp &p, Operation && op){
-   return farm_info<parallel_execution_omp, Operation>(p,op);
+   return farm_info<parallel_execution_omp, Operation>(p,std::forward<Operation>(op) );
 }
 }
 #endif

--- a/include/seq/farm.h
+++ b/include/seq/farm.h
@@ -48,7 +48,7 @@ void farm(sequential_execution , GenFunc &&in, Operation && op, SinkFunc &&sink 
 
 template <typename Operation>
 farm_info<sequential_execution,Operation> farm(sequential_execution &s, Operation && op){
-   return farm_info<sequential_execution, Operation>(s ,op);
+   return farm_info<sequential_execution, Operation>(s , std::forward<Operation>(op) );
 }
 }
 #endif

--- a/include/tbb/farm.h
+++ b/include/tbb/farm.h
@@ -123,7 +123,7 @@ template <typename GenFunc, typename Operation>
 
 template <typename Operation>
 farm_info<parallel_execution_tbb,Operation> farm(parallel_execution_tbb &p, Operation && op){
-   return farm_info<parallel_execution_tbb, Operation>(p,op);
+   return farm_info<parallel_execution_tbb, Operation>(p, std::forward<Operation>(op) );
 }
 }
 #endif


### PR DESCRIPTION
Function objects have been revised and accordingly modified to being passed as forwarding reference.