### PR TITLE
Modified  divide and conquer interface - Issue 123

### DIFF
--- a/include/omp/divideandconquer.h
+++ b/include/omp/divideandconquer.h
@@ -134,18 +134,6 @@ Output divide_and_conquer(parallel_execution_omp &p, Input & problem, Output ini
 }
 
 
-/*
-
-template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Operation>
- void Reduce( InputIt first, InputIt last, OutputIt firstOut, Operation && op, MoreIn ... inputs ) {
-    while( first != last ) {
-        *firstOut = op( *first, *inputs ... );
-        NextInputs( inputs... );
-        first++;
-        firstOut++;
-    }
-}
-*/
 }
 #endif
 

--- a/include/omp/divideandconquer.h
+++ b/include/omp/divideandconquer.h
@@ -27,48 +27,49 @@
 
 namespace grppi{
 
-template <typename Input, typename Output, typename DivFunc, typename Operation, typename MergeFunc>
-Output internal_divide_and_conquer(parallel_execution_omp &p, Input & problem, Output init,
+template <typename Input, typename DivFunc, typename Operation, typename MergeFunc>
+typename std::result_of<Operation(Input)>::type internal_divide_and_conquer(parallel_execution_omp &p, Input & problem, 
             DivFunc && divide, Operation && op, MergeFunc && merge, std::atomic<int> & num_threads) {
    
     // Sequential execution fo internal implementation
+    using  Output = typename std::result_of<Operation(Input)>::type;
     sequential_execution seq;
-    auto out = init;
+    Output out;
     if(num_threads.load()>0){
        auto subproblems = divide(problem);
 
 
     if(subproblems.size()>1){
-         std::vector<Output> partials(subproblems.size());
-         int division = 1;
+         std::vector<Output> partials(subproblems.size()-1);
+         int division = 0;
          auto i = subproblems.begin()+1;
          for(i; i != subproblems.end()&& num_threads.load()>0; i++, division++){
             //THREAD
              #pragma omp task firstprivate(i, division) shared(divide, op, merge, partials, num_threads)
              {
-                 partials[division] = internal_divide_and_conquer(p, *i, partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+                 partials[division] = internal_divide_and_conquer(p, *i, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
               //END TRHEAD
              }
              num_threads --;
              
           }
           for(i; i != subproblems.end(); i++){
-              partials[division] = divide_and_conquer(seq,*i,partials[division], divide, op, merge);
+              partials[division] = divide_and_conquer(seq,*i, divide, op, merge);
           }
           
           //Main thread works on the first subproblem.
-          partials[0] = internal_divide_and_conquer(p, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+          out = internal_divide_and_conquer(p, *subproblems.begin(), std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
 
           #pragma omp taskwait
 
-          for(int i = 0; i<partials.size();i++){ // MarcoA - this is moved to the user code
+          for(int i = 0; i<partials.size();i++){ 
               merge(partials[i], out);
           }
         }else{
           out = op(problem);
         }
      }else{
-        return divide_and_conquer(seq, problem, out, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+        return divide_and_conquer(seq, problem, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
      }
      return out;
 
@@ -76,21 +77,21 @@ Output internal_divide_and_conquer(parallel_execution_omp &p, Input & problem, O
 
 }
 
-template <typename Input, typename Output, typename DivFunc, typename Operation, typename MergeFunc>
-Output divide_and_conquer(parallel_execution_omp &p, Input & problem, Output init,
+template <typename Input, typename DivFunc, typename Operation, typename MergeFunc>
+typename std::result_of<Operation(Input)>::type divide_and_conquer(parallel_execution_omp &p, Input & problem, 
             DivFunc && divide, Operation && op, MergeFunc && merge) {
 
     // Sequential execution fo internal implementation
     sequential_execution seq;
-
+    using Output = typename std::result_of<Operation(Input)>::type;
     std::atomic<int> num_threads( p.num_threads );
-    auto out = init;
+    Output out;
     if(num_threads.load()>0){
        auto subproblems = divide(problem);
 
       if(subproblems.size()>1){
-          std::vector<Output> partials(subproblems.size());
-    	  int division = 1;
+          std::vector<Output> partials(subproblems.size()-1);
+    	  int division = 0;
   
           #pragma omp parallel
           {
@@ -101,34 +102,34 @@ Output divide_and_conquer(parallel_execution_omp &p, Input & problem, Output ini
               //THREAD
               #pragma omp task firstprivate(i,division) shared(partials,divide,op,merge, num_threads)
               {
-                  partials[division] = internal_divide_and_conquer(p, *i, partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+                  partials[division] = internal_divide_and_conquer(p, *i,  std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
               //END TRHEAD
               }
                   num_threads --;
 
           }
           for(i; i != subproblems.end(); i++){
-              partials[division] = divide_and_conquer(seq,*i,partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+              partials[division] = divide_and_conquer(seq,*i, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
           }
 
     	  //Main thread works on the first subproblem.
         
          if(num_threads.load()>0){
-            partials[0] = internal_divide_and_conquer(p, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+            out = internal_divide_and_conquer(p, *subproblems.begin(),  std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
         }else{
-            partials[0] = divide_and_conquer(seq, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+            out = divide_and_conquer(seq, *subproblems.begin(),  std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
         }
           #pragma omp taskwait
           }
           }
-          for(int i = 0; i<partials.size();i++){ // MarcoA - this is moved to the user code
+          for(int i = 0; i<partials.size();i++){ 
               merge(partials[i], out);
           }
         }else{
           out = op(problem);
         }
     }else{
-        return divide_and_conquer(seq, problem, out, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+        return divide_and_conquer(seq, problem, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
     }
     return out;
 }

--- a/include/seq/divideandconquer.h
+++ b/include/seq/divideandconquer.h
@@ -22,22 +22,24 @@
 #define GRPPI_DIVIDEANDCONQUER_SEQ_H
 namespace grppi{
 
-template <typename Input, typename Output, typename DivFunc, typename Operation, typename MergeFunc>
- Output divide_and_conquer(sequential_execution &s, Input &problem, Output init, DivFunc &&divide,
+template <typename Input, typename DivFunc, typename Operation, typename MergeFunc>
+typename std::result_of<Operation(Input)>::type divide_and_conquer(sequential_execution &s, Input &problem, DivFunc &&divide,
                                Operation &&op, MergeFunc &&merge) {
      
+    using Output = typename std::result_of<Operation(Input)>::type;
     auto subproblems = divide(problem);
-    Output out = init;
+    Output out;
     if(subproblems.size()>1){
         std::vector<Output> partials(subproblems.size());
 	int division = 0;
         for(auto i = subproblems.begin(); i != subproblems.end(); i++, division++){
             //THREAD
-            partials[division] = divide_and_conquer(s, *i, partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge) );
+            partials[division] = divide_and_conquer(s, *i, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge) );
             //END THREAD
         }
+        out = partials[0] ;
         //JOIN
-        for(int i = 0; i<partials.size();i++){
+        for(int i = 1; i<partials.size();i++){
               merge(partials[i], out);
         }
     }else{

--- a/include/seq/divideandconquer.h
+++ b/include/seq/divideandconquer.h
@@ -23,40 +23,29 @@
 namespace grppi{
 
 template <typename Input, typename Output, typename DivFunc, typename Operation, typename MergeFunc>
- void divide_and_conquer(sequential_execution &s, Input &problem, Output &output, DivFunc &&divide,
+ Output divide_and_conquer(sequential_execution &s, Input &problem, Output init, DivFunc &&divide,
                                Operation &&op, MergeFunc &&merge) {
      
     auto subproblems = divide(problem);
+    Output out = init;
     if(subproblems.size()>1){
         std::vector<Output> partials(subproblems.size());
 	int division = 0;
         for(auto i = subproblems.begin(); i != subproblems.end(); i++, division++){
             //THREAD
-                divide_and_conquer(s, *i, partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge) );
+            partials[division] = divide_and_conquer(s, *i, partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge) );
             //END THREAD
         }
         //JOIN
         for(int i = 0; i<partials.size();i++){
-              merge(partials[i], output);
+              merge(partials[i], out);
         }
     }else{
 
-        op(problem, output);
-
+        out = op(problem);
     }
+    return out;
 }
 
-
-/*
-template <typename InputIt, typename OutputIt, typename ... MoreIn, typename Operation>
- void Reduce( InputIt first, InputIt last, OutputIt firstOut, Operation && op, MoreIn ... inputs ) {
-    while( first != last ) {
-        *firstOut = op( *first, *inputs ... );
-        NextInputs( inputs... );
-        first++;
-        firstOut++;
-    }
-}
-*/
 }
 #endif

--- a/include/tbb/divideandconquer.h
+++ b/include/tbb/divideandconquer.h
@@ -25,27 +25,28 @@
 
 #include <tbb/tbb.h>
 namespace grppi{
-template <typename Input, typename Output, typename DivFunc, typename Operation, typename MergeFunc>
-Output internal_divide_and_conquer(parallel_execution_tbb &p, Input & problem, Output init,
+template <typename Input, typename DivFunc, typename Operation, typename MergeFunc>
+typename std::result_of<Operation(Input)>::type internal_divide_and_conquer(parallel_execution_tbb &p, Input & problem,
             DivFunc && divide, Operation && op, MergeFunc && merge, std::atomic<int>& num_threads) {
    
     // Sequential execution fo internal implementation
+    using Output = typename std::result_of<Operation(Input)>::type;
     sequential_execution seq;
-    auto out = init;
+    Output out;
     if(num_threads.load()>0){
        auto subproblems = divide(problem);
 
 
     if(subproblems.size()>1){
-         std::vector<Output> partials(subproblems.size());
-         int division = 1;
+         std::vector<Output> partials(subproblems.size()-1);
+         int division = 0;
          tbb::task_group g;
          auto i = subproblems.begin()+1;
          for(i ; i != subproblems.end() && num_threads.load() > 0; i++, division++){
             //THREAD
             g.run(
               [&p, i, &partials, division, &divide, &op, &merge, &num_threads](){
-                 partials[division] = internal_divide_and_conquer(p, *i, partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+                 partials[division] = internal_divide_and_conquer(p, *i, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
               }
             );
               //END TRHEAD
@@ -53,14 +54,14 @@ Output internal_divide_and_conquer(parallel_execution_tbb &p, Input & problem, O
           }
           //Main thread works on the first subproblem.
           for(i; i != subproblems.end(); i++){
-              partials[division] = divide_and_conquer(seq,*i,partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+              partials[division] = divide_and_conquer(seq,*i, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
           }
 
-          partials[0] = internal_divide_and_conquer(p, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+          out = internal_divide_and_conquer(p, *subproblems.begin(),  std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
 
           g.wait();
 
-          for(int i = 0; i<partials.size();i++){ // MarcoA - this is moved to the user code
+          for(int i = 0; i<partials.size();i++){ 
               merge(partials[i], out);
           }
 
@@ -69,26 +70,27 @@ Output internal_divide_and_conquer(parallel_execution_tbb &p, Input & problem, O
         }
 
      }else{
-        return divide_and_conquer(seq, problem, out, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+        return divide_and_conquer(seq, problem, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
      }
      return out;
 }
 
-template <typename Input, typename Output, typename DivFunc, typename Operation, typename MergeFunc>
-Output divide_and_conquer(parallel_execution_tbb &p, Input & problem, Output init,
+template <typename Input, typename DivFunc, typename Operation, typename MergeFunc>
+typename std::result_of<Operation(Input)>::type divide_and_conquer(parallel_execution_tbb &p, Input & problem,
             DivFunc && divide, Operation && op, MergeFunc && merge) {
 
     // Sequential execution fo internal implementation
+    using Output = typename std::result_of<Operation(Input)>::type;
     sequential_execution seq;
-    auto out = init; 
+    Output out; 
     std::atomic<int> num_threads( p.num_threads );
 
     if(num_threads.load()>0){
        auto subproblems = divide(problem);
 
       if(subproblems.size()>1){
-          std::vector<Output> partials(subproblems.size());
-    	  int division = 1;
+          std::vector<Output> partials(subproblems.size()-1);
+    	  int division = 0;
           tbb::task_group g;
              
           auto i = subproblems.begin()+1;
@@ -96,33 +98,33 @@ Output divide_and_conquer(parallel_execution_tbb &p, Input & problem, Output ini
               //THREAD
               g.run(
                  [&p, i, &partials, division, &divide, &op, &merge, &num_threads](){
-                     partials[division] = internal_divide_and_conquer(p, *i, partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+                     partials[division] = internal_divide_and_conquer(p, *i, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
                   }
               );
               num_threads--;
               //END TRHEAD
           }
           for(i; i != subproblems.end(); i++){
-              partials[division] = divide_and_conquer(seq,*i,partials[division], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+              partials[division] = divide_and_conquer(seq,*i, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
           }
           //Main thread works on the first subproblem.
 
           if(num_threads.load()>0){
-            partials[0] = internal_divide_and_conquer(p, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
+            out = internal_divide_and_conquer(p, *subproblems.begin(),  std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge), num_threads);
           }else{
-            partials[0] = divide_and_conquer(seq, *subproblems.begin(), partials[0], std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+            out = divide_and_conquer(seq, *subproblems.begin(),  std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
           }
 
           g.wait();
 
-          for(int i = 0; i<partials.size();i++){ // MarcoA - this is moved to the user code
+          for(int i = 0; i<partials.size();i++){ 
               merge(partials[i], out);
           }
         }else{
           out = op(problem);
         }
     }else{
-       return divide_and_conquer(seq, problem, out, std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
+       return divide_and_conquer(seq, problem,  std::forward<DivFunc>(divide), std::forward<Operation>(op), std::forward<MergeFunc>(merge));
     }
     return out;
 }

--- a/tests/divideandconquer-fibonacci.cpp
+++ b/tests/divideandconquer-fibonacci.cpp
@@ -55,7 +55,7 @@ void fibonacci_example() {
     for(int v=0;v<40;v++){
     int find = 1;
     int out = 0;
-    out = divide_and_conquer(p, v, out,
+    out = divide_and_conquer(p, v, 
         [&](auto & v){
            std::vector< int > subproblem;
     	   if(v<2) subproblem.push_back(v);
@@ -65,8 +65,8 @@ void fibonacci_example() {
            }
            return subproblem;
         },
-        [&](auto & problem){
-           auto partial = 0;
+        [&](auto problem){
+           int partial = 0;
            if(problem!=0){
               int a=1, b=1;
               for(int i = 3; i <= problem; i++){

--- a/tests/divideandconquer-fibonacci.cpp
+++ b/tests/divideandconquer-fibonacci.cpp
@@ -55,7 +55,7 @@ void fibonacci_example() {
     for(int v=0;v<40;v++){
     int find = 1;
     int out = 0;
-    divide_and_conquer(p, v, out,
+    out = divide_and_conquer(p, v, out,
         [&](auto & v){
            std::vector< int > subproblem;
     	   if(v<2) subproblem.push_back(v);
@@ -65,9 +65,9 @@ void fibonacci_example() {
            }
            return subproblem;
         },
-        [&](auto & problem, auto & partial){
-           if(problem==0) partial = 0;
-           else{
+        [&](auto & problem){
+           auto partial = 0;
+           if(problem!=0){
               int a=1, b=1;
               for(int i = 3; i <= problem; i++){
                  int c = a + b;
@@ -76,6 +76,7 @@ void fibonacci_example() {
              }
              partial = b;
            }
+           return partial;
         },
         [&](auto & partial, auto & out){
            out += partial;

--- a/tests/divideandconquer-quicksort.cpp
+++ b/tests/divideandconquer-quicksort.cpp
@@ -55,7 +55,7 @@ void dividec_example1() {
     }
     std::vector<int> out;
     
-    out = divide_and_conquer(p,v, out,
+    out = divide_and_conquer(p,v,
                      [&](vector<int> & v){
         std::vector<std::vector<int>> subproblem;
         if(v.size() == 1){ subproblem.push_back(v);return subproblem; }

--- a/tests/divideandconquer-quicksort.cpp
+++ b/tests/divideandconquer-quicksort.cpp
@@ -55,7 +55,7 @@ void dividec_example1() {
     }
     std::vector<int> out;
     
-    divide_and_conquer(p,v, out,
+    out = divide_and_conquer(p,v, out,
                      [&](vector<int> & v){
         std::vector<std::vector<int>> subproblem;
         if(v.size() == 1){ subproblem.push_back(v);return subproblem; }
@@ -78,8 +78,10 @@ void dividec_example1() {
 
         return subproblem;
         },
-        [&](const vector<int> & problem, vector<int> & out){
+        [&](const vector<int> & problem){
+            vector<int> out ();
             out.push_back(problem[0]);
+            return out;
               
         },
         [&](auto & partial, auto & out){

--- a/tests/divideandconquer1.cpp
+++ b/tests/divideandconquer1.cpp
@@ -50,7 +50,7 @@ void dividec_example1() {
     }
     int out = 0;
 
-    divide_and_conquer(p,v, out,
+    out = divide_and_conquer(p,v, out,
                      [&](auto & v){
         std::vector<std::vector<int>> subproblem;
         if(v.size() <= 2){ subproblem.push_back(v);return subproblem; }
@@ -73,10 +73,12 @@ void dividec_example1() {
         return subproblem;
     },
     // base case management: vector<int> ->int
-    [&](const vector<int> & problem, int & out){
+    [&](const vector<int> & problem){
+        auto out = 0;
         //                out = 0;
         //std::cout << "Base case problem size " << problem.size() << "\n";
         for(int i= 0; i< problem.size(); i++) out += problem[i];
+        return out;
     },
     // Merge: vector<T> -> T
         [&](auto & partial, auto & out){

--- a/tests/divideandconquer1.cpp
+++ b/tests/divideandconquer1.cpp
@@ -50,7 +50,7 @@ void dividec_example1() {
     }
     int out = 0;
 
-    out = divide_and_conquer(p,v, out,
+    out = divide_and_conquer(p,v,
                      [&](auto & v){
         std::vector<std::vector<int>> subproblem;
         if(v.size() <= 2){ subproblem.push_back(v);return subproblem; }


### PR DESCRIPTION
Updated version for the divide and conquer pattern.

Changes:
- The intial value is taken by value.
- Now the output is returned instead of be taken by reference.
- The base problem operation should only take a single argument for the problem and return the result. 
- Removed unnecessary commented code.