### PR TITLE
Typo in pipeline implementation with make_pair - Issue 176

### DIFF
--- a/include/native/pipeline.h
+++ b/include/native/pipeline.h
@@ -301,7 +301,7 @@ void stages(parallel_execution_native &p, Stream& st,
                  st.push(item);
                  nend++;
                  if(nend == se.exectype.num_threads) 
-                      q.push(make_pair(optional< typename std::result_of<Operation(typename Stream::value_type::first_type::value_type) >::type >(), -1));
+                      q.push(std::make_pair(optional< typename std::result_of<Operation(typename Stream::value_type::first_type::value_type) >::type >(), -1));
                 
                  //Deregister the thread in the execution model
                  se.exectype.deregister_thread();

--- a/include/omp/pipeline.h
+++ b/include/omp/pipeline.h
@@ -202,7 +202,7 @@ template <typename Operation, typename Stream,typename... Stages>
         st.push(item);
         nend++;
         if(nend == se.exectype.num_threads)
-          q.push(make_pair(optional< typename std::result_of< Operation(typename Stream::value_type::first_type::value_type) >::type >(), -1));
+          q.push(std::make_pair(optional< typename std::result_of< Operation(typename Stream::value_type::first_type::value_type) >::type >(), -1));
       }              
     }
     stages(p, q, std::forward<Stages>(sgs) ... );


### PR DESCRIPTION
Fixed missing "std::" in native and omp pipeline.