### PR TITLE
Modified composed stream reduce interface - Issue 239

### DIFF
--- a/include/common/patterns.h
+++ b/include/common/patterns.h
@@ -33,14 +33,17 @@ class pipeline_info{
       pipeline_info(E &p, Stage s, Stages ... sts) : exectype{p}, stages{std::make_tuple(s, sts...)} {}
 };
 
-template <typename E,class Operation, class RedFunc>
+template <typename E,class Combiner, typename Identity>
 class reduction_info
 {
    public:
-      Operation task;
-      RedFunc red;
+      Combiner combine_op;
+      int window_size;
+      int offset;
+      Identity identity;
       E & exectype;
-      reduction_info(E &s, Operation farm, RedFunc r) : task{farm}, red{r}, exectype{s} {}
+      reduction_info(E &s,int ws, int off, Identity iden, Combiner comb) : 
+        exectype{s}, window_size{ws}, offset{off}, identity{iden}, combine_op{comb} {}
 };
 
 template <typename E,class Operation>

--- a/include/native/pipeline.h
+++ b/include/native/pipeline.h
@@ -153,39 +153,75 @@ void pipeline_impl(parallel_execution_native & ex, InQueue& input_queue,
 }
 
 //Item reduce stage
-template <typename Transformer, typename Reducer, typename InQueue>
-void pipeline_impl(parallel_execution_native & ex, InQueue & input_queue,
-                   reduction_info<parallel_execution_native, Transformer, Reducer> & reduction_obj) 
+template <typename Combiner, typename Identity, typename InQueue, typename ...MoreTransformers>
+void pipeline_impl(parallel_execution_native & ex, InQueue & input_queue, 
+                   reduction_info<parallel_execution_native, Combiner, Identity> & reduction_obj, MoreTransformers ...more_transform_ops) 
 {
   using reduction_type = 
-      reduction_info<parallel_execution_native,Transformer,Reducer>;
+      reduction_info<parallel_execution_native,Combiner,Identity>;
 
-  pipeline_impl(ex, input_queue, std::forward<reduction_type>(reduction_obj));
+  pipeline_impl(ex, input_queue, std::forward<reduction_type&&>(reduction_obj), std::forward<MoreTransformers...>(more_transform_ops...));
 }
 
-template <typename Transformer, typename Reducer, typename InQueue>
+template <typename Combiner, typename Identity, typename InQueue, typename ...MoreTransformers>
 void pipeline_impl(parallel_execution_native & ex, InQueue & input_queue,
-                   reduction_info<parallel_execution_native,Transformer,Reducer> && reduction_obj) 
+                   reduction_info<parallel_execution_native, Combiner, Identity> && reduction_obj, MoreTransformers ...more_transform_ops)
+{
+  using reduction_type = 
+      reduction_info<parallel_execution_native,Combiner,Identity>;
+  pipeline_impl_ordered(ex, input_queue, std::forward<reduction_type>(reduction_obj), std::forward<MoreTransformers...>(more_transform_ops...));
+}
+
+template <typename Combiner, typename Identity, typename InQueue, typename ...MoreTransformers>
+void pipeline_impl_ordered(parallel_execution_native & ex, InQueue & input_queue,
+                   reduction_info<parallel_execution_native,Combiner,Identity> && reduction_obj, MoreTransformers ...more_transform_ops) 
 {
   using namespace std;
+  using namespace std::experimental;
   vector<thread> tasks;
   using input_type = typename InQueue::value_type;
-  using result_type = typename result_of<Transformer(input_type)>::type;
+  using input_value_type = typename input_type::first_type::value_type;
+  
+  using result_value_type = typename result_of<Combiner(input_value_type, input_value_type)>::type;
+  using result_type = pair<optional<result_value_type>, long>;
+
   mpmc_queue<result_type> output_queue{ex.queue_size,ex.lockfree};
-
-  for (int th=0; th<reduction_obj.exectype.num_threads; th++) {
-    tasks.emplace_back([&]() {
-      auto item = input_queue.pop( );
-      while (item) {
-        auto local =  input_queue.task(item) ;
-        output_queue.push( local ) ;
-        item = input_queue.pop( );
+  
+  thread windower_task([&](){
+    vector<input_value_type> values;
+    long out_order=0;
+    auto item {input_queue.pop()};
+    for(;;){
+      while (item.first && values.size() != reduction_obj.window_size) {
+        values.push_back(*item.first);
+        item = input_queue.pop();       
       }
-      output_queue.push(result_type{}) ;
-    });
-  }
+      if (values.size() > 0) {
+        auto reduced_value = reduce(reduction_obj.exectype, values.begin(), values.end(), reduction_obj.identity,
+            std::forward<Combiner>(reduction_obj.combine_op));
+        output_queue.push({{reduced_value}, out_order});      
+        out_order++;
+        if (item.first) {
+          if (reduction_obj.offset <= reduction_obj.window_size) {
+            values.erase(values.begin(), values.begin() + reduction_obj.offset);
+          }
+          else {
+            values.erase(values.begin(), values.end());
+            auto diff = reduction_obj.offset - reduction_obj.window_size;
+            while (diff > 0 && item.first) {
+              item = input_queue.pop();
+              diff--;
+            }
+          }
+        }
+      }
+      if (!item.first) break;
+    }
+    output_queue.push({{},-1});
+  });
 
-  for (auto && t : tasks) { t.join(); }
+  pipeline_impl(ex, output_queue, forward<MoreTransformers>(more_transform_ops) ... );
+  windower_task.join();
 }
 
 //Filtering stage

--- a/include/stream_reduce.h
+++ b/include/stream_reduce.h
@@ -46,10 +46,10 @@ namespace grppi {
 /**
 \todo To be documented
 */
-template <typename Execution, typename Operation, typename RedFunc>
+template <typename Execution, typename Combiner, typename Identity>
 auto 
-stream_reduce(Execution & ex, Operation && op, RedFunc && red){
-   return reduction_info<Execution, Operation, RedFunc>(ex, op, red);
+stream_reduce(Execution & ex, int window_size, int offset, Identity identity, Combiner && combine_op){
+   return reduction_info<Execution, Combiner, Identity>(ex, window_size, offset, identity, combine_op);
 }
 
 /**

--- a/tests/stream_reduce_example.cpp
+++ b/tests/stream_reduce_example.cpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <experimental/optional>
 
+#include <pipeline.h>
 #include <stream_reduce.h>
 
 using namespace std;
@@ -52,7 +53,7 @@ void reduce_example1(){
     std::vector<int> stream( 10000, 1 );
     int index = 0;
     int n=0;
-    stream_reduce( p,
+/*    stream_reduce( p,
         //Window size
         1000000,
         1000000,
@@ -72,7 +73,33 @@ void reduce_example1(){
             total += a;
             std::cout<<"PARTIAL REDUCE : "<<a<<" TOTAL " <<total<< std::endl;
         }
-    );
+    );*/
+
+    n = 100;
+    int out = 0;
+    pipeline(p,
+       [&]() -> optional<int>{
+         if(n > 0) {
+            n--;
+            return n;
+         }
+         else {
+           return {};
+         }
+       },
+       [](int a){
+         return a+1;
+       },
+       grppi::stream_reduce(p,
+          3, 2, 0,
+          [](int a, int b){
+             return a+b;
+          }
+       ),
+       [&](int a){
+         std::cout<<a<<std::endl;
+       }
+  );
 }
 
 int main() {

--- a/tests/stream_reduce_example.cpp
+++ b/tests/stream_reduce_example.cpp
@@ -53,7 +53,7 @@ void reduce_example1(){
     std::vector<int> stream( 10000, 1 );
     int index = 0;
     int n=0;
-/*    stream_reduce( p,
+    stream_reduce( p,
         //Window size
         1000000,
         1000000,
@@ -73,33 +73,7 @@ void reduce_example1(){
             total += a;
             std::cout<<"PARTIAL REDUCE : "<<a<<" TOTAL " <<total<< std::endl;
         }
-    );*/
-
-    n = 100;
-    int out = 0;
-    pipeline(p,
-       [&]() -> optional<int>{
-         if(n > 0) {
-            n--;
-            return n;
-         }
-         else {
-           return {};
-         }
-       },
-       [](int a){
-         return a+1;
-       },
-       grppi::stream_reduce(p,
-          3, 2, 0,
-          [](int a, int b){
-             return a+b;
-          }
-       ),
-       [&](int a){
-         std::cout<<a<<std::endl;
-       }
-  );
+    );
 }
 
 int main() {

--- a/unit_tests/composed_stream_reduce.cpp
+++ b/unit_tests/composed_stream_reduce.cpp
@@ -1,0 +1,166 @@
+/**
+* @version		GrPPI v0.2
+* @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
+* @license		GNU/GPL, see LICENSE.txt
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You have received a copy of the GNU General Public License in LICENSE.txt
+* also available in <http://www.gnu.org/licenses/gpl.html>.
+*
+* See COPYRIGHT.txt for copyright notices and details.
+*/
+#include <atomic>
+#include <experimental/optional>
+
+#include <gtest/gtest.h>
+
+#include "pipeline.h"
+#include "stream_reduce.h"
+#include "poly/polymorphic_execution.h"
+
+
+using namespace std;
+using namespace grppi;
+template <typename T>
+using optional = std::experimental::optional<T>;
+
+template <typename T>
+class composed_reduce_test : public ::testing::Test {
+public:
+  T execution_;
+  polymorphic_execution poly_execution_ = 
+    make_polymorphic_execution<T>();
+
+  // Variables
+  int out;
+  int window;
+  int offset;
+
+  // Vectors
+  vector<int> v{};
+  
+  // Invocation counter
+  std::atomic<int> invocations_gen{0};
+  std::atomic<int> invocations_kernel{0};
+  std::atomic<int> invocations_reduce{0};
+  std::atomic<int> invocations_cons{0};
+  std::atomic<int> invocations_stage{0};
+
+  void setup_window_offset() {
+    out = 0;
+    v = vector<int>{1,2,3,4,5,6};
+    window = 2;
+    offset = 1;
+  }
+
+  void check_window_offset() {
+    EXPECT_EQ(7, invocations_gen);
+    EXPECT_EQ(6, invocations_stage);
+    EXPECT_EQ(25, invocations_reduce);
+    EXPECT_EQ(5, invocations_cons);
+    EXPECT_EQ(45, this->out);
+  }
+
+  void setup_offset_window() {
+    out = 0;
+    v = vector<int>{1,2,3,4,5,6,7,8,9,10};
+    window = 2;
+    offset = 4;
+  }
+
+  void check_offset_window() {
+    EXPECT_EQ(11, invocations_gen);
+    EXPECT_EQ(10, invocations_stage);
+    EXPECT_EQ(15, invocations_reduce);
+    EXPECT_EQ(3, invocations_cons);
+    EXPECT_EQ(39, this->out);
+  }
+};
+
+// Test for execution policies defined in supported_executions.h
+using executions = ::testing::Types<
+  grppi::parallel_execution_native,
+  grppi::parallel_execution_omp
+>;
+
+TYPED_TEST_CASE(composed_reduce_test, executions);
+
+TYPED_TEST(composed_reduce_test, static_window_offset)
+{
+  this->setup_window_offset();
+  grppi::pipeline( this->execution_,
+    [this]() -> optional<int>{
+      this->invocations_gen++;
+      if(this-> v.size() > 0) {
+        auto problem = this->v.back();
+        this->v.pop_back();
+        return problem;
+      }
+      else {
+        return {};
+      }
+    },
+    [this](int a){
+      this->invocations_stage++;
+       return a+1;
+    },
+    grppi::stream_reduce(this->execution_,
+      this->window, this->offset, 0,
+      [this](int a, int b){
+        this->invocations_reduce++;
+        return a+b;
+      }
+    ),
+    [this](int a){
+      this->invocations_cons++;
+      this-> out += a;
+    }
+  );
+  this->check_window_offset();
+}
+
+TYPED_TEST(composed_reduce_test, static_offset_window)
+{
+  this->setup_offset_window();
+  grppi::pipeline( this->execution_,
+    [this]() -> optional<int>{
+      this->invocations_gen++;
+      if(this-> v.size() > 0) {
+        auto problem = this->v.back();
+        this->v.pop_back();
+        return problem;
+      }
+      else {
+        return {};
+      }
+    },
+    [this](int a){
+      this->invocations_stage++;
+       return a+1;
+    },
+    grppi::stream_reduce(this->execution_,
+      this->window, this->offset, 0,
+      [this](int a, int b){
+        this->invocations_reduce++;
+        return a+b;
+      }
+    ),
+    [this](int a){
+      this->invocations_cons++;
+      this-> out += a;
+    }
+  );
+  this->check_offset_window();
+}
+
+
+
+

--- a/unit_tests/stream_reduce.cpp
+++ b/unit_tests/stream_reduce.cpp
@@ -393,5 +393,35 @@ TYPED_TEST(stream_reduce_test, poly_offset_window)
   this->check_offset_window();
 }
 
-
+TYPED_TEST(stream_reduce_test, static_composed)
+{
+  grppi::pipeline( this->execution_,
+    [this]() -> optional<int>{
+      this->invocations_gen++;
+      if(this-> v.size() > 0) {
+        auto problem = this->v.back();
+        this->v.pop_back();
+        return problem;
+      }
+      else {
+        return {};
+      }
+    },
+    [this](int a){
+      this->invocations_stage++;
+       return a+1;
+    },
+    grppi::stream_reduce(this->execution,
+      3, 1, 0,
+      [this](int a, int b){
+        this->invocations_reduce++;
+        return a+b;
+      }
+    ),
+    [this](int a){
+      this->invocations_cons++;
+      this-> out += a;
+    }
+  );
+}
 

--- a/unit_tests/stream_reduce.cpp
+++ b/unit_tests/stream_reduce.cpp
@@ -100,6 +100,7 @@ public:
     EXPECT_EQ(35, this->out);
   }
 
+
   void setup_offset_window() {
     out = 0;
     v = vector<int>{1,2,3,4,5,6,7,8,9,10};
@@ -393,35 +394,4 @@ TYPED_TEST(stream_reduce_test, poly_offset_window)
   this->check_offset_window();
 }
 
-TYPED_TEST(stream_reduce_test, static_composed)
-{
-  grppi::pipeline( this->execution_,
-    [this]() -> optional<int>{
-      this->invocations_gen++;
-      if(this-> v.size() > 0) {
-        auto problem = this->v.back();
-        this->v.pop_back();
-        return problem;
-      }
-      else {
-        return {};
-      }
-    },
-    [this](int a){
-      this->invocations_stage++;
-       return a+1;
-    },
-    grppi::stream_reduce(this->execution,
-      3, 1, 0,
-      [this](int a, int b){
-        this->invocations_reduce++;
-        return a+b;
-      }
-    ),
-    [this](int a){
-      this->invocations_cons++;
-      this-> out += a;
-    }
-  );
-}
 


### PR DESCRIPTION
I have modified the interface of the stream reduce in order to align this interface with its stand-alone version. Currently, this composition is only supported by OpenMP and native execution policies.