### PR TITLE
Issue 257: Documented and refactored parallel_execution_native

### DIFF
--- a/include/common/mpmc_queue.h
+++ b/include/common/mpmc_queue.h
@@ -43,6 +43,18 @@ class mpmc_queue{
       mpmc_queue<T>(int q_size, queue_mode q_mode ):
            size{q_size}, buffer{std::vector<T>(q_size)}, mode{q_mode}, pread{0}, pwrite{0}, internal_pread{0}, internal_pwrite{0} { }
       
+      mpmc_queue(mpmc_queue && q) :
+        size{q.size},
+        buffer{std::move(q.buffer)},
+        mode{q.mode},
+        pread{q.pread.load()},
+        pwrite{q.pwrite.load()},
+        internal_pread{q.internal_pread.load()},
+        internal_pwrite{q.internal_pwrite.load()},
+        m{},
+        empty{},
+        full{}
+      {}
      
       bool is_empty () const noexcept;
       T pop () ;

--- a/include/native/divideconquer.h
+++ b/include/native/divideconquer.h
@@ -52,8 +52,7 @@ internal_divide_conquer(parallel_execution_native &p,
         for(i = subproblems.begin()+1; i != subproblems.end() && num_threads.load()>0 ; i++, division++){
             //THREAD
           tasks.emplace_back([&](auto i, int division) {
-            // Register the thread in the execution model
-            p.register_thread(); 
+            auto manager = p.thread_manager();
 
             partials[division] = internal_divide_conquer(p, *i,
               std::forward<Divider>(divide_op),
@@ -61,8 +60,6 @@ internal_divide_conquer(parallel_execution_native &p,
               std::forward<Combiner>(combine_op), 
               num_threads);
 
-            // Deregister the thread in the execution model
-            p.deregister_thread();
           }, i, division);
 
           num_threads--;
@@ -155,17 +152,12 @@ divide_conquer(parallel_execution_native & ex,
     for(i = subproblems.begin()+1; i != subproblems.end() && num_threads.load()>0; i++, division++) {
       //THREAD
       tasks.emplace_back([&](auto i, int division) { 
-        // Register the thread in the execution model
-        ex.register_thread();
-
+        auto manager = ex.thread_manager();
         partials[division] = internal_divide_conquer(ex, *i, 
           std::forward<Divider>(divide_op), 
           std::forward<Solver>(solve_op), 
           std::forward<Combiner>(combine_op), 
           num_threads);
-                 
-        // Deregister the thread in the execution model
-        ex.deregister_thread();
       }, i, division);
 
       num_threads--;

--- a/include/native/farm.h
+++ b/include/native/farm.h
@@ -62,7 +62,7 @@ void farm(parallel_execution_native & ex, Generator generate_op,
   vector<thread> tasks;
   for (int i=0; i<ex.concurrency_degree(); ++i) {
     tasks.emplace_back([&](){
-      ex.register_thread();
+      auto manger = ex.thread_manager();
 
       auto item{queue.pop()};
       while(item) {
@@ -70,8 +70,6 @@ void farm(parallel_execution_native & ex, Generator generate_op,
         item = queue.pop();
       }
       queue.push(item);
-
-      ex.deregister_thread();
     });
   }
 
@@ -115,7 +113,7 @@ void farm(parallel_execution_native & ex, Generator generate_op,
 
   for (int i=0; i<ex.concurrency_degree(); ++i) {
     tasks.emplace_back([&](){
-      ex.register_thread();
+      auto manager = ex.thread_manager();
 
       auto item{generated_queue.pop()};
       while (item) {
@@ -127,21 +125,17 @@ void farm(parallel_execution_native & ex, Generator generate_op,
       if (done_threads==ex.concurrency_degree()) {
         transformed_queue.push(transformed_type{});
       }
-
-      ex.deregister_thread();
     });
   }
 
   tasks.emplace_back([&](){
-    ex.register_thread();
+    auto manager = ex.thread_manager();
 
     auto item{transformed_queue.pop()};
     while (item) {
       consume_op( item.value() );
       item = transformed_queue.pop( );
     }
-
-    ex.deregister_thread();
   });
 
   for (;;) {

--- a/include/native/farm.h
+++ b/include/native/farm.h
@@ -57,7 +57,7 @@ void farm(parallel_execution_native & ex, Generator generate_op,
 {
   using namespace std;
   using result_type = typename result_of<Generator()>::type;
-  mpmc_queue<result_type> queue{ex.queue_size,ex.lockfree};
+  auto queue = ex.make_queue<result_type>();
 
   vector<thread> tasks;
   for (int i=0; i<ex.concurrency_degree(); ++i) {
@@ -105,8 +105,8 @@ void farm(parallel_execution_native & ex, Generator generate_op,
       typename result_of<Transformer(generated_value_type)>::type;
   using transformed_type = optional<transformed_value_type>;
 
-  mpmc_queue<generated_type> generated_queue{ex.queue_size,ex.lockfree};
-  mpmc_queue<transformed_type> transformed_queue{ex.queue_size, ex.lockfree};
+  auto generated_queue = ex.make_queue<generated_type>();
+  auto transformed_queue = ex.make_queue<transformed_type>();
 
   atomic<int> done_threads(0);
   vector<thread> tasks;

--- a/include/native/map.h
+++ b/include/native/map.h
@@ -62,17 +62,13 @@ void map(parallel_execution_native & ex,
 
     auto out = first_out + (elemperthr * i);
     tasks.emplace_back([&](InputIt begin, InputIt end, OutputIt out) {
-      // Register the thread in the execution model
-      ex.register_thread();
+      auto manager = ex.thread_manager();
           
       while (begin!=end) {
         *out = transf_op(*begin);
         begin++;
         out++;
       }
-          
-      // Deregister the thread in the execution model
-      ex.deregister_thread();
     }, begin, end, out);
   }
   //Map main threads
@@ -126,10 +122,7 @@ void map(parallel_execution_native& ex,
     //Begin task
     tasks.emplace_back([&](InputIt begin, InputIt end, OutputIt out, 
       int tid, int nelem, OtherInputIts ... more_inputs) {
-
-      // Register the thread in the execution model
-      ex.register_thread();
-
+        auto manager = ex.thread_manager();
       advance_iterators(nelem*tid, more_inputs ...);
       while (begin!=end) {
         *out = transf_op(*begin, *more_inputs ...);
@@ -137,9 +130,6 @@ void map(parallel_execution_native& ex,
         begin++;
         out++;
       }
-
-      // Deregister the thread in the execution model
-      ex.deregister_thread();
     }, begin, end, out, i, elemperthr, more_inputs...);
     //End task
   }

--- a/include/native/mapreduce.h
+++ b/include/native/mapreduce.h
@@ -74,10 +74,9 @@ Result map_reduce(parallel_execution_native & ex,
         (first + elements_per_thread * (i+1));
 
     tasks.emplace_back([&,begin,end,i](){
-        ex.register_thread();
+        auto manager = ex.thread_manager();
         partial_results[i] = map_reduce(seq, begin, end, partial_results[i], 
             forward<Transformer>(transform_op), forward<Combiner>(combine_op));
-        ex.deregister_thread();
     });
   }
 

--- a/include/native/parallel_execution_native.h
+++ b/include/native/parallel_execution_native.h
@@ -83,7 +83,8 @@ inline void thread_registry::deregister_thread() noexcept
   using namespace std;
   while (lock_.test_and_set(memory_order_acquire)) {}
   auto this_id = this_thread::get_id();
-  ids_.erase(remove(begin(ids_), end(ids_), this_id), end(ids_));
+  auto current = find(begin(ids_), end(ids_), this_id);
+  *current = {}; //Empty thread
   lock_.clear(memory_order_release);
 }
 

--- a/include/native/stencil.h
+++ b/include/native/stencil.h
@@ -40,8 +40,7 @@ template <typename InputIt, typename OutputIt, typename Operation, typename NFun
        auto out = firstOut + (elemperthr * i);
 
        tasks.emplace_back([&](InputIt begin, InputIt end, OutputIt out) {
-         // Register the thread in the execution model
-         p.register_thread();
+         auto manager = p.thread_manager();
 
          while (begin!=end) {
            auto neighbors = neighbor(begin);
@@ -49,9 +48,6 @@ template <typename InputIt, typename OutputIt, typename Operation, typename NFun
            begin++;
            out++;
          }
-
-         // Deregister the thread in the execution model
-         p.deregister_thread();
        }, begin, end, out);
     }
    //MAIN 

--- a/include/native/stream_filter.h
+++ b/include/native/stream_filter.h
@@ -55,8 +55,8 @@ void stream_filter(parallel_execution_native & ex, Generator generate_op,
   using generated_type = typename result_of<Generator()>::type;
   using item_type = pair<generated_type,long>;
 
-  mpmc_queue<item_type> generated_queue{ex.queue_size,ex.lockfree};
-  mpmc_queue<item_type> filtered_queue{ex.queue_size,ex.lockfree};
+  auto generated_queue = ex.make_queue<item_type>();
+  auto filtered_queue = ex.make_queue<item_type>();
 
   //THREAD 1-(N-1) EXECUTE FILTER AND PUSH THE VALUE IF TRUE
   vector<thread> tasks;

--- a/include/native/stream_filter.h
+++ b/include/native/stream_filter.h
@@ -62,7 +62,7 @@ void stream_filter(parallel_execution_native & ex, Generator generate_op,
   vector<thread> tasks;
   for (int i=0; i<ex.concurrency_degree()-1; ++i) {
     tasks.emplace_back([&](){
-      ex.register_thread();
+      auto manager = ex.thread_manager();
 
       // queue a pair element - order
       auto item{generated_queue.pop()};
@@ -78,14 +78,12 @@ void stream_filter(parallel_execution_native & ex, Generator generate_op,
       }
       //If is the last element
       filtered_queue.push(make_pair(item.first, -1 ));
-
-      ex.deregister_thread();
     });
   }
 
   //LAST THREAD CALL FUNCTION OUT WITH THE FILTERED ELEMENTS
   thread consumer([&](){
-    ex.register_thread();
+    auto manager = ex.thread_manager();
 
     int done_threads = 0; 
     
@@ -143,8 +141,6 @@ void stream_filter(parallel_execution_native & ex, Generator generate_op,
       item_buffer.erase(it_find);
       order++;
     }
-           
-    ex.deregister_thread();
   });
 
   //THREAD 0 ENQUEUE ELEMENTS

--- a/include/native/stream_iteration.h
+++ b/include/native/stream_iteration.h
@@ -31,14 +31,14 @@ namespace grppi{
 
 template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Stages>
 void stream_iteration(parallel_execution_native &p, GenFunc && in, pipeline_info<parallel_execution_native , Stages...> && se, Predicate && condition, OutFunc && out){
-   auto queue = p.make_queue<typename std::result_of<GenFunc()>::type>()
+   auto queue = p.make_queue<typename std::result_of<GenFunc()>::type>();
    auto queueOut = p.make_queue<typename std::result_of<GenFunc()>::type>();
    std::atomic<int> nend (0);
    std::atomic<int> nelem (0);
    std::atomic<bool> sendFinish( false );
    //Stream generator
    std::thread gen([&](){
-     auto manager = ex.thread_manager();
+     auto manager = p.thread_manager();
       while(1){
          auto k = in();
          if(!k){

--- a/include/native/stream_iteration.h
+++ b/include/native/stream_iteration.h
@@ -31,8 +31,8 @@ namespace grppi{
 
 template<typename GenFunc, typename Predicate, typename OutFunc, typename ...Stages>
 void stream_iteration(parallel_execution_native &p, GenFunc && in, pipeline_info<parallel_execution_native , Stages...> && se, Predicate && condition, OutFunc && out){
-   mpmc_queue< typename std::result_of<GenFunc()>::type > queue(p.queue_size,p.lockfree);
-   mpmc_queue< typename std::result_of<GenFunc()>::type > queueOut(p.queue_size,p.lockfree);
+   auto queue = p.make_queue<typename std::result_of<GenFunc()>::type>()
+   auto queueOut = p.make_queue<typename std::result_of<GenFunc()>::type>();
    std::atomic<int> nend (0);
    std::atomic<int> nelem (0);
    std::atomic<bool> sendFinish( false );
@@ -80,8 +80,8 @@ void stream_iteration(parallel_execution_native &p, GenFunc && in, pipeline_info
 template<typename GenFunc, typename Operation, typename Predicate, typename OutFunc>
  void stream_iteration(parallel_execution_native &p, GenFunc && in, farm_info<parallel_execution_native,Operation> && se, Predicate && condition, OutFunc && out){
    std::vector<std::thread> tasks;
-   mpmc_queue< typename std::result_of<GenFunc()>::type > queue(p.queue_size,p.lockfree);
-   mpmc_queue< typename std::result_of<GenFunc()>::type > queueOut(p.queue_size,p.lockfree);
+   auto queue = p.make_queue<typename std::result_of<GenFunc()>::type>();
+   auto queueOut = p.make_queue<typename std::result_of<GenFunc()>::type>();
    std::atomic<int> nend (0);
    //Stream generator
    std::thread gen([&](){


### PR DESCRIPTION
Important refactoring of parallel_execution_native:
* Fully documented
* The thread table part has been factored out to a new thread_registry class.
* The registration/deregistration is now managed by a RAII class
* Many small improvements in parallel_execution_native itself.