### PR TITLE
qf25072017: Quick fix for bug introduced in omp execution policy

### DIFF
--- a/include/omp/pipeline.h
+++ b/include/omp/pipeline.h
@@ -116,7 +116,7 @@ void pipeline_impl_ordered(parallel_execution_omp & ex, InQueue & input_queue,
   using result_value_type = typename result_of<Combiner(input_value_type, input_value_type)>::type;
   using result_type = pair<optional<result_value_type>, long>;
 
-  mpmc_queue<result_type> output_queue{ex.queue_size,ex.lockfree};
+  auto output_queue = ex.make_queue<result_type>();
 
   #pragma omp task shared(output_queue, input_queue, reduction_obj)
   {


### PR DESCRIPTION
Generalization of `parallel_execution_omp` introduced a bug.

Using `omp_get_num_threads()` on a serial section does not obtain the number of threads and fixes the number of threads to ' 1'. This was causing streaming patterns to freeze when comunicating throug queues.