### PR TITLE
Review map

### DIFF
--- a/include/common/iterator.h
+++ b/include/common/iterator.h
@@ -21,7 +21,76 @@
 #ifndef GRPPI_COMMON_ITERATOR_H
 #define GRPPI_COMMON_ITERATOR_H
 
+#include <utility>
+
 namespace grppi{
+
+namespace internal {
+
+template <typename F, typename T, std::size_t ... I>
+decltype(auto) apply_iterator_increment_impl(F && f, T & t, std::index_sequence<I...>)
+{
+  return std::forward<F>(f)(*std::get<I>(t)++...);
+}
+
+} // namespace internal
+
+/**
+\brief Applies a callable object to the values obtained from the interators in a tuple.
+This function takes callable object `f` and a tuple-like with iterators (e.g.
+the result of `make_tuple(it1, it2, it3)`)
+
+and performs the action
+
+~~~{.cpp}
+f(*it1++, *it2++, *it3++);
+~~~
+
+\tparam Type of the callable object.
+\tparam T Tuple type containing a tuple of iterators
+\param f Callable object to be invoked.
+\param t Tuple of iterators.
+\post All iterators in t have been incremented
+\post `f` has been invoked with the contents of the iterator in the tuple.
+*/
+template <typename F, typename T>
+decltype(auto) apply_iterators_increment(F && f, T & t)
+{
+  using tuple_raw_type = std::decay_t<T>;
+  constexpr std::size_t size = std::tuple_size<tuple_raw_type>::value;
+  return internal::apply_iterator_increment_impl(std::forward<F>(f), t,
+      std::make_index_sequence<size>());
+}
+
+namespace internal {
+
+template <typename T, std::size_t ... I>
+auto iterators_next_impl(T && t, int n, std::index_sequence<I...>) {
+  return make_tuple(
+    std::next(std::get<I>(t), n)...
+  );
+}
+
+} // namespace internal
+
+/**
+\brief Computes next n steps from a tuple of iterators.
+\tparam T Tuple type cotaining a tuple of iterators.
+\param t Tuple of iterators.
+\param n Number of steps to advance.
+\note This function is the equivalent to std::next for a tuple of iterators.
+\returns A new tuple with the result iterators.
+*/
+template <typename T>
+auto iterators_next(T && t, int n) {
+  using tuple_raw_type = std::decay_t<T>;
+  constexpr std::size_t size = std::tuple_size<tuple_raw_type>::value;
+  return internal::iterators_next_impl(std::forward<T>(t), n,
+      std::make_index_sequence<size>());
+}
+
+
+
 
 /// Advance a pack of iterators by a delta.
 /// Every iterator in the parameter pack in is increased n steps.
@@ -44,6 +113,6 @@ void advance_iterators(InputIt & ... in) {
 } 
 
 
-}
+} // namespace grppi
 
 #endif

--- a/include/common/iterator.h
+++ b/include/common/iterator.h
@@ -22,6 +22,7 @@
 #define GRPPI_COMMON_ITERATOR_H
 
 #include <utility>
+#include <tuple>
 
 namespace grppi{
 

--- a/include/common/iterator.h
+++ b/include/common/iterator.h
@@ -1,5 +1,5 @@
 /**
-* @version		GrPPI v0.2
+* @version		GrPPI v0.3
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -61,6 +61,46 @@ decltype(auto) apply_iterators_increment(F && f, T & t)
   constexpr std::size_t size = std::tuple_size<tuple_raw_type>::value;
   return internal::apply_iterator_increment_impl(std::forward<F>(f), t,
       std::make_index_sequence<size>());
+}
+
+namespace internal {
+
+template <typename F, typename T, std::size_t ... I>
+decltype(auto) apply_iterators_indexed_impl(F && f, T && t, std::size_t i,
+    std::index_sequence<I...>)
+{
+  return std::forward<F>(f)(std::get<I>(t)[i]...);
+}
+
+} // namespace internal
+
+/**
+\brief Applies a callable object to the values obtained from the iterators in a tuple
+by indexing.
+This function takes callable object `f`, a tuple-like with iterators (e.g.
+the result of `make_tuple(it1, it2, it3)`) and an integral index `i`.
+
+and performs the action
+
+~~~{.cpp}
+f(it1[i], it2[i], it3[i]);
+~~~
+
+\tparam F Type of the callable object.
+\tparam T Tuple type containing a tuple of iterators
+\param f Callable object to be invoked.
+\param t Tuple of iterators.
+\param i Integral index to apply to each interator.
+\post All iterators in t have been incremented
+\post `f` has been invoked with the contents of the iterator in the tuple.
+*/
+template <typename F, typename T>
+decltype(auto) apply_iterators_indexed(F && f, T && t, std::size_t i)
+{
+  using tuple_raw_type = std::decay_t<T>;
+  constexpr std::size_t size = std::tuple_size<tuple_raw_type>::value;
+  return internal::apply_iterators_indexed_impl(std::forward<F>(f), 
+      std::forward<T>(t), i, std::make_index_sequence<size>());
 }
 
 namespace internal {

--- a/include/native/map.h
+++ b/include/native/map.h
@@ -44,15 +44,15 @@ paralell execution.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
-\param transf_op Transformation operation.
+\param transform_op Transformation operation.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
 void map(parallel_execution_native & ex, 
          InputIt first, InputIt last, OutputIt first_out, 
-         Transformer && transf_op)
+         Transformer && transform_op)
 {
   ex.chunked_map(std::make_tuple(first), first_out, std::distance(first,last),
-    transf_op);
+    transform_op);
 }
 
 /**
@@ -66,18 +66,18 @@ parallel execution.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
-\param transf_op Transformation operation.
+\param transform_op Transformation operation.
 \param more_firsts Additional iterators with first elements of additional sequences.
 */
 template <typename InputIt, typename OutputIt, typename Transformer,
           typename ... OtherInputIts> 
 void map(parallel_execution_native& ex, 
          InputIt first, InputIt last, OutputIt first_out, 
-         Transformer && transf_op, 
+         Transformer && transform_op, 
          OtherInputIts ... more_inputs)
 {
   ex.chunked_map(std::make_tuple(first,more_inputs...), first_out,
-      std::distance(first,last), transf_op);
+      std::distance(first,last), transform_op);
 }
 
 /**

--- a/include/native/map.h
+++ b/include/native/map.h
@@ -51,7 +51,7 @@ void map(parallel_execution_native & ex,
          InputIt first, InputIt last, OutputIt first_out, 
          Transformer && transf_op)
 {
-  ex.chunked_map(first, first_out, std::distance(first,last),
+  ex.chunked_map(std::make_tuple(first), first_out, std::distance(first,last),
     transf_op);
 }
 
@@ -76,9 +76,8 @@ void map(parallel_execution_native& ex,
          Transformer && transf_op, 
          OtherInputIts ... more_inputs)
 {
-  ex.chunked_map_multi(std::make_tuple(first,more_inputs...), first_out,
-      std::distance(first,last),
-      transf_op);
+  ex.chunked_map(std::make_tuple(first,more_inputs...), first_out,
+      std::distance(first,last), transf_op);
 }
 
 /**

--- a/include/native/map.h
+++ b/include/native/map.h
@@ -22,7 +22,9 @@
 #define GRPPI_NATIVE_MAP_H
 
 #include "parallel_execution_native.h"
-#include "../common/iterator.h"
+
+#include <tuple>
+#include <iterator>
 
 namespace grppi {
 
@@ -51,7 +53,7 @@ void map(parallel_execution_native & ex,
          InputIt first, InputIt last, OutputIt first_out, 
          Transformer && transform_op)
 {
-  ex.chunked_map(std::make_tuple(first), first_out, std::distance(first,last),
+  ex.apply_map(std::make_tuple(first), first_out, std::distance(first,last),
     transform_op);
 }
 
@@ -76,7 +78,7 @@ void map(parallel_execution_native& ex,
          Transformer && transform_op, 
          OtherInputIts ... more_inputs)
 {
-  ex.chunked_map(std::make_tuple(first,more_inputs...), first_out,
+  ex.apply_map(std::make_tuple(first,more_inputs...), first_out,
       std::distance(first,last), transform_op);
 }
 

--- a/include/native/parallel_execution_native.h
+++ b/include/native/parallel_execution_native.h
@@ -1,5 +1,5 @@
 /**
-* @version		GrPPI v0.2
+* @version		GrPPI v0.3
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <vector>
 #include <type_traits>
+#include <tuple>
 
 namespace grppi {
 
@@ -245,9 +246,9 @@ public:
   */
   template <typename ... InputIterators, typename OutputIterator, 
             typename Transformer>
-  void chunked_map(std::tuple<InputIterators...> firsts,
+  void apply_map(std::tuple<InputIterators...> firsts,
       OutputIterator first_out, 
-      int sequence_size, Transformer transform_op);
+      std::size_t sequence_size, Transformer transform_op);
 
 public: 
   /**
@@ -271,10 +272,10 @@ private:
 
 template <typename ... InputIterators, typename OutputIterator, 
           typename Transformer>
-void parallel_execution_native::chunked_map(
+void parallel_execution_native::apply_map(
     std::tuple<InputIterators...> firsts,
     OutputIterator first_out, 
-    int sequence_size, Transformer transform_op)
+    std::size_t sequence_size, Transformer transform_op)
 {
   using namespace std;
 

--- a/include/native/worker_pool.h
+++ b/include/native/worker_pool.h
@@ -1,0 +1,87 @@
+/**
+* @version		GrPPI v0.3
+* @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
+* @license		GNU/GPL, see LICENSE.txt
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You have received a copy of the GNU General Public License in LICENSE.txt
+* also available in <http://www.gnu.org/licenses/gpl.html>.
+*
+* See COPYRIGHT.txt for copyright notices and details.
+*/
+
+#ifndef GRPPI_NATIVE_WOKER_POOL_H
+#define GRPPI_NATIVE_WORKER_POOL_H
+
+#include <thread>
+
+namespace grppi {
+
+/**
+\brief Pool of worker threads.
+This class offers a simple pool of worker threads.
+\note Current version does not support more threads than the initially set
+number of threads.
+*/
+class worker_pool {
+  public:
+
+    /**
+    \brief Creates a worker pool with a number of threads.
+    \param num_threads Number of threads for the pool.
+    */
+    worker_pool(int num_threads) noexcept : num_threads_{num_threads} {}
+
+    /**
+    \brief Destructs the worker pool after joining with all threads in the 
+    pool.
+    */
+    ~worker_pool() noexcept { wait(); }
+    
+    /**
+    \brief Launch a function in the pool.
+    \pre Number of running threads must be lower than number of pool threads.
+    \tparam E Execution policy type.
+    \tparam F Type for launched function.
+    \tparam Args Type for launched function arguments.
+    \param ex Execution policy.
+    \param f Function to be launched.
+    \param args Arguments for launched function.
+    */
+    template <typename E, typename F, typename ... Args>
+    void launch(E & ex, F f, Args && ... args) {
+      // TODO: Precondition
+      if (num_threads_ <= workers_.size()) 
+        throw std::runtime_error{"Too many threads in worker"};
+
+      workers_.emplace_back([=,&ex]() {
+        auto manager = ex.thread_manager();
+        f(args...);
+      });
+    }
+
+    /**
+    \brief Wait until all launched tasks have been completed.
+    \post Number of workers is 0.
+    */
+    void wait() noexcept {
+      for (auto && w : workers_) { w.join(); }
+      workers_.clear();
+    }
+
+  private:
+    const int num_threads_;
+    std::vector<std::thread> workers_;
+};
+
+}
+
+#endif

--- a/include/omp/map.h
+++ b/include/omp/map.h
@@ -45,18 +45,18 @@ parallel execution.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
-\param transf_op Transformation operation.
+\param transform_op Transformation operation.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
 void map(parallel_execution_omp & ex, 
          InputIt first, InputIt last, 
          OutputIt first_out, 
-         Transformer && transf_op)
+         Transformer && transform_op)
 {
   const std::size_t sequence_size = std::distance(first, last);
   #pragma parallel for
   for (std::size_t i=0; i<sequence_size; ++i) {
-    first_out[i] = transf_op(first[i]);
+    first_out[i] = transform_op(first[i]);
   }
 }
 
@@ -79,13 +79,13 @@ template <typename InputIt, typename OutputIt, typename Transformer,
 void map(parallel_execution_omp & ex, 
          InputIt first, InputIt last, 
          OutputIt first_out, 
-         Transformer && transf_op, 
+         Transformer && transform_op, 
          OtherInputIts ... more_firsts)
 {
   const std::size_t sequence_size = std::distance(first, last);
   #pragma parallel for
   for (std::size_t i=0; i<sequence_size; ++i) {
-    first_out[i] = transf_op(first[i], more_firsts[i]...);
+    first_out[i] = transform_op(first[i], more_firsts[i]...);
   }
 }
 

--- a/include/omp/map.h
+++ b/include/omp/map.h
@@ -25,6 +25,9 @@
 
 #include "parallel_execution_omp.h"
 
+#include <tuple>
+#include <iterator>
+
 namespace grppi {
 
 /**
@@ -48,16 +51,13 @@ parallel execution.
 \param transform_op Transformation operation.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
-void map(parallel_execution_omp & ex, 
+void map(const parallel_execution_omp & ex, 
          InputIt first, InputIt last, 
          OutputIt first_out, 
          Transformer && transform_op)
 {
-  const std::size_t sequence_size = std::distance(first, last);
-  #pragma parallel for
-  for (std::size_t i=0; i<sequence_size; ++i) {
-    first_out[i] = transform_op(first[i]);
-  }
+  ex.apply_map(make_tuple(first), first_out, std::distance(first,last),
+      transform_op);
 }
 
 /**
@@ -76,17 +76,14 @@ execution.
 */
 template <typename InputIt, typename OutputIt, typename Transformer,
           typename ... OtherInputIts>
-void map(parallel_execution_omp & ex, 
+void map(const parallel_execution_omp & ex, 
          InputIt first, InputIt last, 
          OutputIt first_out, 
          Transformer && transform_op, 
          OtherInputIts ... more_firsts)
 {
-  const std::size_t sequence_size = std::distance(first, last);
-  #pragma parallel for
-  for (std::size_t i=0; i<sequence_size; ++i) {
-    first_out[i] = transform_op(first[i], more_firsts[i]...);
-  }
+  ex.apply_map(make_tuple(first,more_firsts...), first_out, std::distance(first,last),
+      transform_op);
 }
 
 /**

--- a/include/omp/map.h
+++ b/include/omp/map.h
@@ -53,10 +53,10 @@ void map(parallel_execution_omp & ex,
          OutputIt first_out, 
          Transformer && transf_op)
 {
-  const int sequence_size = std::distance(first, last);
+  const std::size_t sequence_size = std::distance(first, last);
   #pragma parallel for
-  for (int i=0; i<sequence_size; ++i) {
-    *first_out++ = transf_op(*first++);
+  for (std::size_t i=0; i<sequence_size; ++i) {
+    first_out[i] = transf_op(first[i]);
   }
 }
 
@@ -82,42 +82,11 @@ void map(parallel_execution_omp & ex,
          Transformer && transf_op, 
          OtherInputIts ... more_firsts)
 {
-  const int sequence_size = std::distance(first, last);
+  const std::size_t sequence_size = std::distance(first, last);
   #pragma parallel for
-  for (int i=0; i<sequence_size; ++i) {
-    *first_out++ = transf_op(*first++,*more_firsts++...);
+  for (std::size_t i=0; i<sequence_size; ++i) {
+    first_out[i] = transf_op(first[i], more_firsts[i]...);
   }
-/*
-  //Calculate number of elements per thread
-  int numElements = last - first;
-  int elemperthr = numElements/ex.concurrency_degree();
-
-  //Create tasks
-  #pragma omp parallel
-  {
-    #pragma omp single nowait
-    {
-      for(int i=1;i<ex.concurrency_degree();i++){
-
-      #pragma omp task firstprivate(i)
-      {
-        internal_map(ex, first, last, first_out,
-                     std::forward<Transformer>(transf_op) , i, elemperthr, 
-                     more_firsts ...);
-      }
-      //End task
-     }
-
-     //Map main thread
-     internal_map(ex, first,last, first_out, 
-                  std::forward<Transformer>(transf_op), 0, elemperthr, 
-                  more_firsts ...);
-
-    //Join threads
-    #pragma omp taskwait
-    }
-  }
-*/
 }
 
 /**

--- a/include/seq/map.h
+++ b/include/seq/map.h
@@ -48,9 +48,9 @@ execution.
 \param transf_op Transformation operation.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
-void map(sequential_execution & ex, 
+void map(sequential_execution ex, 
          InputIt first, InputIt last, OutputIt first_out, 
-         Transformer && transf_op) 
+         Transformer transf_op) 
 {
   while (first != last) {
     *first_out = transf_op(*first);
@@ -75,9 +75,9 @@ execution.
 */
 template <typename InputIt, typename OutputIt, typename Transformer,
           typename ... OtherInputIts>
-void map(sequential_execution & ex, 
+void map(sequential_execution ex, 
          InputIt first, InputIt last, OutputIt first_out, 
-         Transformer && transf_op, 
+         Transformer transf_op, 
          OtherInputIts ... other_firsts) 
 {
   while (first != last) {

--- a/include/seq/map.h
+++ b/include/seq/map.h
@@ -23,7 +23,8 @@
 
 #include "sequential_execution.h"
 
-#include "../common/iterator.h"
+#include <tuple>
+#include <iterator>
 
 namespace grppi {
 
@@ -41,6 +42,7 @@ execution.
 \tparam InputIt Iterator type used for input sequence.
 \tparam OtuputIt Iterator type used for the output sequence.
 \tparam Transformer Callable type for the transformation operation.
+\param ex Sequential execution policy object.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
@@ -48,15 +50,12 @@ execution.
 \note The sequential_execution object acts exclusively as a tag type.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
-void map(sequential_execution , 
+void map(const sequential_execution & ex, 
          InputIt first, InputIt last, OutputIt first_out, 
          Transformer transform_op) 
 {
-  while (first != last) {
-    *first_out = transform_op(*first);
-    first++;
-    first_out++;
-  }
+  ex.apply_map(make_tuple(first), first_out,
+      std::distance(first, last), transform_op);
 }
 
 /**
@@ -66,6 +65,7 @@ execution.
 \tparam OtuputIt Iterator type used for the output sequence.
 \tparam Transformer Callable type for the transformation operation.
 \tparam OtherInputIts Iterator types used for additional input sequences.
+\param ex Sequential execution policy object.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
@@ -75,17 +75,13 @@ execution.
 */
 template <typename InputIt, typename OutputIt, typename Transformer,
           typename ... OtherInputIts>
-void map(sequential_execution , 
+void map(const sequential_execution & ex, 
          InputIt first, InputIt last, OutputIt first_out, 
          Transformer transform_op, 
          OtherInputIts ... other_firsts) 
 {
-  while (first != last) {
-    *first_out = transform_op(*first, *other_firsts...);
-    advance_iterators(other_firsts...);
-    first++;
-    first_out++;
-  }
+  ex.apply_map(make_tuple(first,other_firsts...), first_out,
+      std::distance(first,last), transform_op);
 }
 
 /**

--- a/include/seq/map.h
+++ b/include/seq/map.h
@@ -52,7 +52,7 @@ void map(sequential_execution & ex,
          InputIt first, InputIt last, OutputIt first_out, 
          Transformer && transf_op) 
 {
-  while(first != last) {
+  while (first != last) {
     *first_out = transf_op(*first);
     first++;
     first_out++;
@@ -80,7 +80,7 @@ void map(sequential_execution & ex,
          Transformer && transf_op, 
          OtherInputIts ... other_firsts) 
 {
-  while( first != last ) {
+  while (first != last) {
     *first_out = transf_op(*first, *other_firsts...);
     advance_iterators(other_firsts...);
     first++;

--- a/include/seq/map.h
+++ b/include/seq/map.h
@@ -1,5 +1,5 @@
 /**
-* @version		GrPPI v0.2
+* @version		GrPPI v0.3
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -41,19 +41,19 @@ execution.
 \tparam InputIt Iterator type used for input sequence.
 \tparam OtuputIt Iterator type used for the output sequence.
 \tparam Transformer Callable type for the transformation operation.
-\param ex Sequential execution policy object.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
-\param transf_op Transformation operation.
+\param transform_op Transformation operation.
+\note The sequential_execution object acts exclusively as a tag type.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
-void map(sequential_execution ex, 
+void map(sequential_execution , 
          InputIt first, InputIt last, OutputIt first_out, 
-         Transformer transf_op) 
+         Transformer transform_op) 
 {
   while (first != last) {
-    *first_out = transf_op(*first);
+    *first_out = transform_op(*first);
     first++;
     first_out++;
   }
@@ -66,22 +66,22 @@ execution.
 \tparam OtuputIt Iterator type used for the output sequence.
 \tparam Transformer Callable type for the transformation operation.
 \tparam OtherInputIts Iterator types used for additional input sequences.
-\param ex Sequential execution policy object.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
-\param transf_op Transformation operation.
+\param transform_op Transformation operation.
 \param more_firsts Additional iterators with first elements of additional sequences.
+\note The sequential_execution object acts exclusively as a tag type.
 */
 template <typename InputIt, typename OutputIt, typename Transformer,
           typename ... OtherInputIts>
-void map(sequential_execution ex, 
+void map(sequential_execution , 
          InputIt first, InputIt last, OutputIt first_out, 
-         Transformer transf_op, 
+         Transformer transform_op, 
          OtherInputIts ... other_firsts) 
 {
   while (first != last) {
-    *first_out = transf_op(*first, *other_firsts...);
+    *first_out = transform_op(*first, *other_firsts...);
     advance_iterators(other_firsts...);
     first++;
     first_out++;

--- a/include/seq/sequential_execution.h
+++ b/include/seq/sequential_execution.h
@@ -1,5 +1,5 @@
 /**
-* @version		GrPPI v0.2
+* @version		GrPPI v0.3
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -21,7 +21,11 @@
 #ifndef GRPPI_SEQ_SEQUENTIAL_EXECUTION_H
 #define GRPPI_SEQ_SEQUENTIAL_EXECUTION_H
 
+#include "../common/iterator.h"
+
 #include <type_traits>
+#include <tuple>
+
 
 namespace grppi {
 
@@ -64,7 +68,41 @@ public:
   \note Sequential execution is always ordered.
   */
   bool is_ordered() const noexcept { return true; }
+
+  /**
+  \brief Applies a trasnformation to multiple sequences leaving the result in
+  another sequence.
+  \tparam InputIterators Iterator types for input sequences.
+  \tparam OutputIterator Iterator type for the output sequence.
+  \tparam Transformer Callable object type for the transformation.
+  \param firsts Tuple of iterators to input sequences.
+  \param first_out Iterator to the output sequence.
+  \param sequence_size Size of the input sequences.
+  \param transform_op Transformation callable object.
+  \pre For every I iterators in the range 
+       `[get<I>(firsts), next(get<I>(firsts),sequence_size))` are valid.
+  \pre Iterators in the range `[first_out, next(first_out,sequence_size)]` are valid.
+  */
+  template <typename ... InputIterators, typename OutputIterator, 
+            typename Transformer>
+  void apply_map(std::tuple<InputIterators...> firsts,
+      OutputIterator first_out, 
+      std::size_t sequence_size, Transformer transform_op) const;
+  
 };
+
+template <typename ... InputIterators, typename OutputIterator, 
+          typename Transformer>
+void sequential_execution::apply_map(
+    std::tuple<InputIterators...> firsts,
+    OutputIterator first_out, 
+    std::size_t sequence_size, Transformer transform_op) const
+{
+  const auto last = std::next(std::get<0>(firsts), sequence_size);
+  while (std::get<0>(firsts) != last) {
+    *first_out++ = apply_iterators_increment(transform_op, firsts);
+  }
+}
 
 /// Determine if a type is a sequential execution policy.
 template <typename E>

--- a/include/tbb/map.h
+++ b/include/tbb/map.h
@@ -57,10 +57,9 @@ void map(parallel_execution_tbb & ex,
 {
   tbb::parallel_for(
     static_cast<std::size_t>(0), 
-    static_cast<std::size_t>((last-first)), 
+    static_cast<std::size_t>(std::distance(first,last)), 
     [&] (std::size_t index){
-      auto current = (first_out+index);
-      *current = transf_op(*(first+index));
+      first_out[index] = transf_op(first[index]);
     }
   );   
 }
@@ -89,10 +88,9 @@ void map(parallel_execution_tbb & ex,
 {
   tbb::parallel_for(
     static_cast<std::size_t>(0),
-    static_cast<std::size_t>((last-first)), 
+    static_cast<std::size_t>(std::distance(first,last)), 
     [&] (std::size_t index){
-      auto current = (first_out+index);
-      *current = transf_op(*(first+index), *(more_firsts+index)...);
+      first_out[index] = transf_op(first[index], more_firsts[index]...);
     }
  );   
 

--- a/include/tbb/map.h
+++ b/include/tbb/map.h
@@ -1,5 +1,5 @@
 /*
-* @version    GrPPI v0.2
+* @version    GrPPI v0.3
 * @copyright    Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license    GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -25,7 +25,8 @@
 
 #include "parallel_execution_tbb.h"
 
-#include <tbb/tbb.h>
+#include <tuple>
+#include <iterator>
 
 namespace grppi {
 
@@ -50,18 +51,13 @@ parallel execution.
 \param transform_op Transformation operation.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
-void map(parallel_execution_tbb & ex, 
+void map(const parallel_execution_tbb & ex, 
          InputIt first, InputIt last, 
          OutputIt first_out, 
          Transformer && transform_op)
 {
-  tbb::parallel_for(
-    static_cast<std::size_t>(0), 
-    static_cast<std::size_t>(std::distance(first,last)), 
-    [&] (std::size_t index){
-      first_out[index] = transform_op(first[index]);
-    }
-  );   
+  ex.apply_map(make_tuple(first), first_out, std::distance(first,last),
+      transform_op);
 }
 
 /**
@@ -81,19 +77,13 @@ parallel execution.
 template <typename InputIt, typename OutputIt, 
           typename Transformer,
           typename ... OtherInputIts>
-void map(parallel_execution_tbb & ex, 
+void map(const parallel_execution_tbb & ex, 
          InputIt first, InputIt last, OutputIt first_out, 
          Transformer && transform_op, 
          OtherInputIts ... more_firsts)
 {
-  tbb::parallel_for(
-    static_cast<std::size_t>(0),
-    static_cast<std::size_t>(std::distance(first,last)), 
-    [&] (std::size_t index){
-      first_out[index] = transform_op(first[index], more_firsts[index]...);
-    }
- );   
-
+  ex.apply_map(make_tuple(first,more_firsts...), first_out, std::distance(first,last),
+      transform_op);
 }
 
 }

--- a/include/tbb/map.h
+++ b/include/tbb/map.h
@@ -47,19 +47,19 @@ parallel execution.
 \param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param first_out Iterator to first elemento of the output sequence.
-\param transf_op Transformation operation.
+\param transform_op Transformation operation.
 */
 template <typename InputIt, typename OutputIt, typename Transformer>
 void map(parallel_execution_tbb & ex, 
          InputIt first, InputIt last, 
          OutputIt first_out, 
-         Transformer && transf_op)
+         Transformer && transform_op)
 {
   tbb::parallel_for(
     static_cast<std::size_t>(0), 
     static_cast<std::size_t>(std::distance(first,last)), 
     [&] (std::size_t index){
-      first_out[index] = transf_op(first[index]);
+      first_out[index] = transform_op(first[index]);
     }
   );   
 }
@@ -83,14 +83,14 @@ template <typename InputIt, typename OutputIt,
           typename ... OtherInputIts>
 void map(parallel_execution_tbb & ex, 
          InputIt first, InputIt last, OutputIt first_out, 
-         Transformer && transf_op, 
+         Transformer && transform_op, 
          OtherInputIts ... more_firsts)
 {
   tbb::parallel_for(
     static_cast<std::size_t>(0),
     static_cast<std::size_t>(std::distance(first,last)), 
     [&] (std::size_t index){
-      first_out[index] = transf_op(first[index], more_firsts[index]...);
+      first_out[index] = transform_op(first[index], more_firsts[index]...);
     }
  );   
 

--- a/include/tbb/parallel_execution_tbb.h
+++ b/include/tbb/parallel_execution_tbb.h
@@ -1,5 +1,5 @@
 /**
-* @version		GrPPI v0.2
+* @version		GrPPI v0.3
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -24,8 +24,12 @@
 #ifdef GRPPI_TBB
 
 #include "../common/mpmc_queue.h"
+#include "../common/iterator.h"
 
 #include <type_traits>
+#include <tuple>
+
+#include <tbb/tbb.h>
 
 namespace grppi {
 
@@ -111,6 +115,26 @@ public:
   */
   int tokens() const noexcept { return num_tokens_; }
 
+  /**
+  \brief Applies a trasnformation to multiple sequences leaving the result in
+  another sequence using available TBB parallelism.
+  \tparam InputIterators Iterator types for input sequences.
+  \tparam OutputIterator Iterator type for the output sequence.
+  \tparam Transformer Callable object type for the transformation.
+  \param firsts Tuple of iterators to input sequences.
+  \param first_out Iterator to the output sequence.
+  \param sequence_size Size of the input sequences.
+  \param transform_op Transformation callable object.
+  \pre For every I iterators in the range 
+       `[get<I>(firsts), next(get<I>(firsts),sequence_size))` are valid.
+  \pre Iterators in the range `[first_out, next(first_out,sequence_size)]` are valid.
+  */
+  template <typename ... InputIterators, typename OutputIterator, 
+            typename Transformer>
+  void apply_map(std::tuple<InputIterators...> firsts,
+      OutputIterator first_out, 
+      std::size_t sequence_size, Transformer transform_op) const;
+
 private:
 
   constexpr static int default_concurrency_degree = 4;
@@ -126,6 +150,22 @@ private:
 
   queue_mode queue_mode_ = queue_mode::blocking;
 };
+
+template <typename ... InputIterators, typename OutputIterator, 
+          typename Transformer>
+void parallel_execution_tbb::apply_map(
+    std::tuple<InputIterators...> firsts,
+    OutputIterator first_out, 
+    std::size_t sequence_size, Transformer transform_op) const
+{
+  tbb::parallel_for(
+    std::size_t{0}, sequence_size, 
+    [&] (std::size_t index){
+      first_out[index] = apply_iterators_indexed(transform_op, firsts, index);
+    }
+ );   
+
+}
 
 /**
 \brief Metafunction that determines if type E is parallel_execution_tbb

--- a/samples/map/CMakeLists.txt
+++ b/samples/map/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(double_sequence)
 add_subdirectory(add_sequences)
+add_subdirectory(daxpy)

--- a/samples/map/README.md
+++ b/samples/map/README.md
@@ -8,3 +8,7 @@ compute a sequence with doubles of those numbers.
 * **add_sequences**: Given the sequence of the first *n* natural numbers,
 and the sequences of the first *n* squares of natural numbers,
 compute a sequence with the addition of those sequence element by element.
+
+* **daxpy**: Generate two random double precission vectors of size *n*
+and a random doulbe precission coefficiente and compute the BLAS daxpy 
+operation (`y = a * x + y`).

--- a/samples/map/daxpy/CMakeLists.txt
+++ b/samples/map/daxpy/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(daxpy main.cpp )
+
+target_link_libraries(daxpy
+  ${CMAKE_THREAD_LIBS_INIT} 
+  ${TBB_LIBRARIES} 
+  ${Boost_LIBRARIES} )

--- a/samples/map/daxpy/README.md
+++ b/samples/map/daxpy/README.md
@@ -1,0 +1,17 @@
+**daxpy**
+
+This progam computes the *daxpy* BLAS operation. That is, given two vectors, `x`
+and `y` of size **n** and a coefficient `a`, it computes the operation:
+
+~~~
+y = a * x + y
+~~~
+
+This program performs the following steps:
+
+1. Generate two vectors with random numbers following an uniform random distribution
+between -100.0 and 100.0.
+2. Generate a cofficient following an uniform random distribution between 1.0
+and 10.0.
+3. Compute the daxpy operation.
+4. Print the resulting vector.

--- a/samples/map/daxpy/main.cpp
+++ b/samples/map/daxpy/main.cpp
@@ -1,0 +1,92 @@
+/**
+* @version    GrPPI v0.1
+* @copyright    Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
+* @license    GNU/GPL, see LICENSE.txt
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You have received a copy of the GNU General Public License in LICENSE.txt
+* also available in <http://www.gnu.org/licenses/gpl.html>.
+*
+* See COPYRIGHT.txt for copyright notices and details.
+*/
+// Standard library
+#include <iostream>
+#include <vector>
+#include <fstream>
+#include <chrono>
+#include <string>
+#include <numeric>
+#include <stdexcept>
+#include <random>
+
+// grppi
+#include "grppi.h"
+
+// Samples shared utilities
+#include "../../util/util.h"
+
+void test_map(grppi::polymorphic_execution & e, int n) {
+  using namespace std;
+
+  mt19937_64 rengine;
+  uniform_real_distribution<double> value_gen{-100.0, 100.0};
+  uniform_real_distribution<double> coef_gen{1.0, 10.0};
+
+  vector<double> x;
+  generate_n(back_inserter(x), n,
+    [&]() { return value_gen(rengine); });
+
+  vector<double> y;
+  generate_n(back_inserter(y), n,
+    [&]() { return value_gen(rengine); });
+  double a = coef_gen(rengine);
+
+  grppi::map(e, begin(x), end(x), begin(y),
+    [a](int vx, int vy) { return a * vx + vy; },
+    begin(y));
+
+  copy(begin(y), end(y), ostream_iterator<int>(cout, " "));
+  cout << endl;
+}
+
+void print_message(const std::string & prog, const std::string & msg) {
+  using namespace std;
+
+  cerr << msg << endl;
+  cerr << "Usage: " << prog << " size mode" << endl;
+  cerr << "  size: Integer value with problem size" << endl;
+  cerr << "  mode:" << endl;
+  print_available_modes(cerr);
+}
+
+
+int main(int argc, char **argv) {
+    
+  using namespace std;
+
+  if(argc < 3){
+    print_message(argv[0], "Invalid number of arguments.");
+    return -1;
+  }
+
+  int n = stoi(argv[1]);
+  if(n <= 0){
+    print_message(argv[0], "Invalid problem size. Use a positive number.");
+    return -1;
+  }
+
+  if (!run_test(argv[2], test_map, n)) {
+    print_message(argv[0], "Invalid policy.");
+    return -1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Detailed refactoring of map pattern.

Now there is a single interface per policy in the policy object (member function apply_map()). All map free functions invoke the corresponding apply_map from the corresponding policy. This sets the path for further generalization.