### PR TITLE
Review divide conquer

### DIFF
--- a/include/native/divideconquer.h
+++ b/include/native/divideconquer.h
@@ -126,7 +126,9 @@ divide_conquer(parallel_execution_native & ex,
                    Divider && divide_op, Solver && solve_op, 
                    Combiner && combine_op) 
 {
-
+  ex.divide_conquer(problem, std::forward<Divider>(divide_op),
+      std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
+/*
   // Sequential execution fo internal implementation
   sequential_execution seq;
   std::atomic<int> num_threads{ex.concurrency_degree()-1};
@@ -186,6 +188,7 @@ divide_conquer(parallel_execution_native & ex,
   else {
     return solve_op(problem);
   }
+*/
 }
 
 /**

--- a/include/native/divideconquer.h
+++ b/include/native/divideconquer.h
@@ -50,7 +50,7 @@ parallel execution.
 */
 template <typename Input, typename Divider, typename Solver, typename Combiner>
 auto divide_conquer(const parallel_execution_native & ex, 
-                   const Input & problem,
+                   Input && problem,
                    Divider && divide_op, Solver && solve_op, 
                    Combiner && combine_op) 
 {

--- a/include/omp/divideconquer.h
+++ b/include/omp/divideconquer.h
@@ -52,12 +52,13 @@ parallel execution.
 */
 template <typename Input, typename Divider, typename Solver, typename Combiner>
 auto divide_conquer(const parallel_execution_omp & ex, 
-                    const Input & input, 
+                    Input && input, 
                     Divider && divide_op, Solver && solve_op, 
                     Combiner && combine_op) 
 {
-  return ex.divide_conquer(input, std::forward<Divider>(divide_op), 
-        std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
+  return ex.divide_conquer(std::forward<Input>(input), 
+        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+        std::forward<Combiner>(combine_op));
 }
 
 /**

--- a/include/omp/divideconquer.h
+++ b/include/omp/divideconquer.h
@@ -25,71 +25,9 @@
 
 #include "parallel_execution_omp.h"
 
+#include <utility>
+
 namespace grppi {
-
-template <typename Input, typename Divider, typename Solver, typename Combiner>
-typename std::result_of<Solver(Input)>::type 
-internal_divide_conquer(parallel_execution_omp & ex, 
-                            Input & input, 
-                            Divider && divide_op, Solver && solve_op, 
-                            Combiner && combine_op, 
-                            std::atomic<int> & num_threads) 
-{
-  // Sequential execution fo internal implementation
-  using  Output = typename std::result_of<Solver(Input)>::type;
-  sequential_execution seq;
-  Output out;
-  if(num_threads.load()>0) {
-    auto subproblems = divide_op(input);
-
-
-    if(subproblems.size()>1) {
-      std::vector<Output> partials(subproblems.size()-1);
-      int division = 0;
-      auto i = subproblems.begin()+1;
-      for(i; i!=subproblems.end() && num_threads.load()>0; i++, division++){
-        //THREAD
-        #pragma omp task firstprivate(i, division) shared(divide_op, solve_op, \
-                combine_op, partials, num_threads)
-        {
-          partials[division] = internal_divide_conquer(ex, *i, 
-              std::forward<Divider>(divide_op), 
-              std::forward<Solver>(solve_op), 
-              std::forward<Combiner>(combine_op), num_threads);
-         //END TRHEAD
-         }
-         num_threads --;
-             
-      }
-      for(i; i != subproblems.end(); i++){
-        partials[division] = divide_conquer(seq, *i, 
-            std::forward<Divider>(divide_op), 
-            std::forward<Solver>(solve_op), 
-            std::forward<Combiner>(combine_op));
-      }
-          
-      //Main thread works on the first subproblem.
-      out = internal_divide_conquer(ex, *subproblems.begin(), 
-          std::forward<Divider>(divide_op), 
-          std::forward<Solver>(solve_op), 
-          std::forward<Combiner>(combine_op), num_threads);
-
-      #pragma omp taskwait
-
-      for(int i = 0; i<partials.size();i++){ 
-        out = combine_op(out,partials[i]);
-      }
-    }
-    else {
-      out = solve_op(input);
-    }
-  }
-  else {
-    return divide_conquer(seq, input, std::forward<Divider>(divide_op), 
-        std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
-  }
-  return out;
-}
 
 /**
 \addtogroup divide_conquer_pattern
@@ -113,80 +51,13 @@ parallel execution.
 \param combiner_op Combiner operation.
 */
 template <typename Input, typename Divider, typename Solver, typename Combiner>
-typename std::result_of<Solver(Input)>::type 
-divide_conquer(parallel_execution_omp & ex, 
-                   Input & input, 
-                   Divider && divide_op, Solver && solve_op, 
-                   Combiner && combine_op) 
+auto divide_conquer(const parallel_execution_omp & ex, 
+                    const Input & input, 
+                    Divider && divide_op, Solver && solve_op, 
+                    Combiner && combine_op) 
 {
-  std::atomic<int> num_threads{ex.concurrency_degree()-1};
-
-  sequential_execution seq;
-
-  using Output = typename std::result_of<Solver(Input)>::type;
-
-  if (num_threads.load()<=0) {
-    return divide_conquer(seq, input, 
-        std::forward<Divider>(divide_op), 
-        std::forward<Solver>(solve_op), 
-        std::forward<Combiner>(combine_op));
-  }
-
-  auto subproblems = divide_op(input);
-  if (subproblems.size()<=1) {
-    return solve_op(input);
-  }
-
-  std::vector<Output> partials(subproblems.size()-1);
-  int division = 0;
-  
-  Output out;
-
-  #pragma omp parallel
-  {
-    #pragma omp single nowait
-    { 
-      auto i = subproblems.begin() + 1;
-      for (i; i!=subproblems.end() && num_threads.load()>0; i++, division++) {
-        //THREAD
-        #pragma omp task firstprivate(i,division) \
-                shared(partials,divide_op,solve_op,combine_op,num_threads)
-        {
-          partials[division] = internal_divide_conquer(ex, *i,
-              std::forward<Divider>(divide_op), 
-              std::forward<Solver>(solve_op), 
-              std::forward<Combiner>(combine_op), num_threads);
-          //END TRHEAD
-        }
-        num_threads --;
-      }
-
-      for (i; i!=subproblems.end(); i++) {
-        partials[division] = divide_conquer(seq, *i, 
-            std::forward<Divider>(divide_op), 
-            std::forward<Solver>(solve_op), 
-            std::forward<Combiner>(combine_op));
-      }
-
-      //Main thread works on the first subproblem.
-      if (num_threads.load()>0) {
-        out = internal_divide_conquer(ex, *subproblems.begin(),
-            std::forward<Divider>(divide_op), 
-            std::forward<Solver>(solve_op), 
-            std::forward<Combiner>(combine_op), num_threads);
-      }
-      else {
-        out = divide_conquer(seq, *subproblems.begin(),
-            std::forward<Divider>(divide_op), 
-            std::forward<Solver>(solve_op), 
-            std::forward<Combiner>(combine_op));
-      }
-      #pragma omp taskwait
-    }
-  }
-
-  for (auto && p : partials) { out = combine_op(out,p); }
-  return out;
+  return ex.divide_conquer(input, std::forward<Divider>(divide_op), 
+        std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
 }
 
 /**

--- a/include/omp/parallel_execution_omp.h
+++ b/include/omp/parallel_execution_omp.h
@@ -215,6 +215,33 @@ public:
                StencilTransformer && transform_op,
                Neighbourhood && neighbour_op) const;
 
+  /**
+  \brief Invoke \ref md_divide-conquer.
+  \tparam Input Type used for the input problem.
+  \tparam Divider Callable type for the divider operation.
+  \tparam Solver Callable type for the solver operation.
+  \tparam Combiner Callable type for the combiner operation.
+  \param ex Sequential execution policy object.
+  \param input Input problem to be solved.
+  \param divider_op Divider operation.
+  \param solver_op Solver operation.
+  \param combine_op Combiner operation.
+  */
+  template <typename Input, typename Divider, typename Solver, typename Combiner>
+  auto divide_conquer(const Input & input, 
+                      Divider && divide_op, 
+                      Solver && solve_op, 
+                      Combiner && combine_op) const; 
+
+private:
+
+  template <typename Input, typename Divider, typename Solver, typename Combiner>
+  auto divide_conquer(const Input & input, 
+                      Divider && divide_op, 
+                      Solver && solve_op, 
+                      Combiner && combine_op,
+                      std::atomic<int> & num_threads) const; 
+
 private:
 
   /**
@@ -395,6 +422,20 @@ void parallel_execution_omp::stencil(
   }
 }
 
+template <typename Input, typename Divider, typename Solver, typename Combiner>
+auto parallel_execution_omp::divide_conquer(
+    const Input & input, 
+    Divider && divide_op, 
+    Solver && solve_op, 
+    Combiner && combine_op) const
+{
+  std::atomic<int> num_threads{concurrency_degree_-1};
+  
+  return divide_conquer(input, std::forward<Divider>(divide_op),
+      std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op),
+      num_threads);
+}
+
 /**
 \brief Metafunction that determines if type E is parallel_execution_omp
 \tparam Execution policy type.
@@ -420,6 +461,76 @@ constexpr bool is_supported<parallel_execution_omp>() {
   return true;
 }
 
+// PRIVATE MEMBERS
+template <typename Input, typename Divider, typename Solver, typename Combiner>
+auto parallel_execution_omp::divide_conquer(
+    const Input & input, 
+    Divider && divide_op, 
+    Solver && solve_op, 
+    Combiner && combine_op,
+    std::atomic<int> & num_threads) const
+{
+  constexpr sequential_execution seq;
+  if (num_threads.load()<=0) {
+    return seq.divide_conquer(input, std::forward<Divider>(divide_op), 
+        std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
+  }
+
+  auto subproblems = divide_op(input);
+  if (subproblems.size()<=1) { return solve_op(input); }
+
+  using subresult_type = 
+      std::decay_t<typename std::result_of<Solver(Input)>::type>;
+  std::vector<subresult_type> partials(subproblems.size()-1);
+
+  auto process_subproblems = [&,this](auto it, std::size_t div) {
+    partials[div] = this->divide_conquer(*it, 
+        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+        std::forward<Combiner>(combine_op), num_threads);
+  };
+
+  int division = 0;
+  subresult_type subresult;
+
+  #pragma omp parallel
+  {
+    #pragma omp single nowait
+    { 
+      auto i = subproblems.begin() + 1;
+      while (i!=subproblems.end() && num_threads.load()>0) {
+        #pragma omp task firstprivate(i,division) \
+                shared(partials,divide_op,solve_op,combine_op,num_threads)
+        {
+           process_subproblems(i, division);
+        }
+        num_threads --;
+        i++;
+        division++;
+      }
+
+      while (i!=subproblems.end()) { 
+        partials[division] = seq.divide_conquer(*i++, 
+          std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+          std::forward<Combiner>(combine_op));
+      }
+
+      //Main thread works on the first subproblem.
+      if (num_threads.load()>0) {
+        subresult = divide_conquer(*subproblems.begin(), 
+            std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+            std::forward<Combiner>(combine_op), num_threads);
+      }
+      else {
+        subresult = seq.divide_conquer(*subproblems.begin(), 
+            std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+            std::forward<Combiner>(combine_op));
+      }
+      #pragma omp taskwait
+    }
+  }
+  return seq.reduce(partials.begin(), partials.size(), subresult, combine_op);
+}
+
 } // end namespace grppi
 
 #else // GRPPI_OMP undefined
@@ -428,7 +539,7 @@ namespace grppi {
 
 
 /// Parallel execution policy.
-/// Empty type if GRPPI_OMP disabled.
+/// Empty type if  GRPPI_OMP disabled.
 struct parallel_execution_omp {};
 
 /**

--- a/include/seq/divideconquer.h
+++ b/include/seq/divideconquer.h
@@ -50,11 +50,11 @@ execution.
 */
 template <typename Input, typename Divider, typename Solver, typename Combiner>
 auto divide_conquer(const sequential_execution & ex, 
-                    const Input & input, 
+                    Input && input, 
                     Divider && divider_op, Solver && solver_op, 
                     Combiner && combiner_op) 
 {
-  return ex.divide_conquer(input, 
+  return ex.divide_conquer(std::forward<Input>(input), 
         std::forward<Divider>(divider_op), std::forward<Solver>(solver_op), 
         std::forward<Combiner>(combiner_op));
 }

--- a/include/seq/divideconquer.h
+++ b/include/seq/divideconquer.h
@@ -1,5 +1,5 @@
 /**
-* @version		GrPPI v0.2
+* @version		GrPPI v0.3
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -22,6 +22,8 @@
 #define GRPPI_SEQ_DIVIDECONQUER_H
 
 #include "sequential_execution.h"
+
+#include <utility>
 
 namespace grppi {
 
@@ -55,28 +57,6 @@ auto divide_conquer(const sequential_execution & ex,
   return ex.divide_conquer(input, 
         std::forward<Divider>(divider_op), std::forward<Solver>(solver_op), 
         std::forward<Combiner>(combiner_op));
-/*
-  auto subproblems = divider_op(input);
-
-  if (subproblems.size()<=1) return solver_op(input);
-
-  using Output = typename std::result_of<Solver(Input)>::type;
-  std::vector<Output> partials;
-  // FORK
-  for (auto && item : subproblems) {
-    //THREAD
-    partials.push_back(divide_conquer(ex, item, 
-        std::forward<Divider>(divider_op), std::forward<Solver>(solver_op), 
-        std::forward<Combiner>(combiner_op)));
-    //END THREAD
-  }
-  Output out = partials[0] ;
-  //JOIN
-  for(int i = 1; i<partials.size();i++){
-    out = combiner_op(out,partials[i]);
-  }
-  return out;
-*/
 }
 
 /**

--- a/include/seq/divideconquer.h
+++ b/include/seq/divideconquer.h
@@ -47,12 +47,15 @@ execution.
 \param combiner_op Combiner operation.
 */
 template <typename Input, typename Divider, typename Solver, typename Combiner>
-typename std::result_of<Solver(Input)>::type 
-divide_conquer(sequential_execution & ex, 
-                   Input & input, 
-                   Divider && divider_op, Solver && solver_op, 
-                   Combiner && combiner_op) 
+auto divide_conquer(const sequential_execution & ex, 
+                    const Input & input, 
+                    Divider && divider_op, Solver && solver_op, 
+                    Combiner && combiner_op) 
 {
+  return ex.divide_conquer(input, 
+        std::forward<Divider>(divider_op), std::forward<Solver>(solver_op), 
+        std::forward<Combiner>(combiner_op));
+/*
   auto subproblems = divider_op(input);
 
   if (subproblems.size()<=1) return solver_op(input);
@@ -73,6 +76,7 @@ divide_conquer(sequential_execution & ex,
     out = combiner_op(out,partials[i]);
   }
   return out;
+*/
 }
 
 /**

--- a/include/seq/sequential_execution.h
+++ b/include/seq/sequential_execution.h
@@ -165,7 +165,7 @@ public:
   */
 
   template <typename Input, typename Divider, typename Solver, typename Combiner>
-  auto divide_conquer(const Input & input, 
+  auto divide_conquer(Input && input, 
                       Divider && divide_op, 
                       Solver && solve_op, 
                       Combiner && combine_op) const; 
@@ -237,14 +237,14 @@ constexpr void sequential_execution::stencil(
 
 template <typename Input, typename Divider, typename Solver, typename Combiner>
 auto sequential_execution::divide_conquer(
-    const Input & input, 
+    Input && input, 
     Divider && divide_op, 
     Solver && solve_op, 
     Combiner && combine_op) const
 {
 
-  auto subproblems = divide_op(input);
-  if (subproblems.size()<=1) return solve_op(input);
+  auto subproblems = divide_op(std::forward<Input>(input));
+  if (subproblems.size()<=1) { return solve_op(std::forward<Input>(input)); }
 
   using subproblem_type = 
       std::decay_t<typename std::result_of<Solver(Input)>::type>;

--- a/include/seq/sequential_execution.h
+++ b/include/seq/sequential_execution.h
@@ -242,6 +242,7 @@ auto sequential_execution::divide_conquer(
     Solver && solve_op, 
     Combiner && combine_op) const
 {
+
   auto subproblems = divide_op(input);
   if (subproblems.size()<=1) return solve_op(input);
 
@@ -253,7 +254,7 @@ auto sequential_execution::divide_conquer(
         std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
         std::forward<Combiner>(combine_op)));
   }
-  return reduce(std::next(solutions.begin()), solutions.end(), solutions[0],
+  return reduce(std::next(solutions.begin()), solutions.size()-1, solutions[0],
       std::forward<Combiner>(combine_op));
 }
 

--- a/include/seq/sequential_execution.h
+++ b/include/seq/sequential_execution.h
@@ -149,6 +149,26 @@ public:
                std::size_t sequence_size,
                StencilTransformer && transform_op,
                Neighbourhood && neighbour_op) const;
+
+  /**
+  \brief Invoke \ref md_divide-conquer.
+  \tparam Input Type used for the input problem.
+  \tparam Divider Callable type for the divider operation.
+  \tparam Solver Callable type for the solver operation.
+  \tparam Combiner Callable type for the combiner operation.
+  \param ex Sequential execution policy object.
+  \param input Input problem to be solved.
+  \param divider_op Divider operation.
+  \param solver_op Solver operation.
+  \param combine_op Combiner operation.
+  */
+
+  template <typename Input, typename Divider, typename Solver, typename Combiner>
+  auto divide_conquer(const Input & input, 
+                      Divider && divide_op, 
+                      Solver && solve_op, 
+                      Combiner && combine_op) const; 
+
 };
 
 template <typename ... InputIterators, typename OutputIterator,
@@ -207,6 +227,28 @@ void sequential_execution::stencil(
     *first_out++ = transform_op(f, 
         apply_increment(std::forward<Neighbourhood>(neighbour_op), firsts));
   }
+}
+
+template <typename Input, typename Divider, typename Solver, typename Combiner>
+auto sequential_execution::divide_conquer(
+    const Input & input, 
+    Divider && divide_op, 
+    Solver && solve_op, 
+    Combiner && combine_op) const
+{
+  auto subproblems = divide_op(input);
+  if (subproblems.size()<=1) return solve_op(input);
+
+  using subproblem_type = 
+      std::decay_t<typename std::result_of<Solver(Input)>::type>;
+  std::vector<subproblem_type> solutions;
+  for (auto && sp : subproblems) {
+    solutions.push_back(divide_conquer(sp, 
+        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+        std::forward<Combiner>(combine_op)));
+  }
+  return reduce(std::next(solutions.begin()), solutions.end(), solutions[0],
+      std::forward<Combiner>(combine_op));
 }
 
 /// Determine if a type is a sequential execution policy.

--- a/include/tbb/divideconquer.h
+++ b/include/tbb/divideconquer.h
@@ -52,12 +52,13 @@ parallel execution.
 */
 template <typename Input, typename Divider, typename Solver, typename Combiner>
 auto divide_conquer(const parallel_execution_tbb & ex, 
-                    const Input & input,
+                    Input && input,
                     Divider && divide_op, Solver && solve_op, 
                     Combiner && combine_op) 
 {
-  return ex.divide_conquer(input, std::forward<Divider>(divide_op), 
-      std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
+  return ex.divide_conquer(std::forward<Input>(input), 
+      std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+      std::forward<Combiner>(combine_op));
 }
 
 /**

--- a/include/tbb/divideconquer.h
+++ b/include/tbb/divideconquer.h
@@ -25,69 +25,9 @@
 
 #include "parallel_execution_tbb.h"
 
-#include <tbb/tbb.h>
+#include <utility>
 
 namespace grppi {
-
-template <typename Input, typename Divider, typename Solver, typename Combiner>
-typename std::result_of<Solver(Input)>::type 
-internal_divide_conquer(parallel_execution_tbb & ex, 
-                            Input & input,
-                            Divider && divide_op, Solver && solve_op, 
-                            Combiner && combine_op, 
-                            std::atomic<int>& num_threads) 
-{
-  // Sequential execution fo internal implementation
-  sequential_execution seq;
-
-  if (num_threads.load()<=0) {
-    return divide_conquer(seq, input, std::forward<Divider>(divide_op), 
-        std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
-  }
-
-  auto subproblems = divide_op(input);
-
-  if (subproblems.size()<=1) {
-    return solve_op(input);
-  }
-
-  using Output = typename std::result_of<Solver(Input)>::type;
-  std::vector<Output> partials(subproblems.size()-1);
-  int division = 0;
-  tbb::task_group g;
-  auto i = subproblems.begin()+1;
-  for(i; i!=subproblems.end() && num_threads.load()>0; i++, division++) {
-    //THREAD
-    g.run(
-      [&ex, i, &partials, division, &divide_op, &solve_op, &combine_op, 
-       &num_threads]() 
-      {
-        partials[division] = internal_divide_conquer(ex, *i, 
-            std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
-            std::forward<Combiner>(combine_op), num_threads);
-      }
-    );
-    //END TRHEAD
-    num_threads--;
-  }
-
-  //Main thread works on the first subproblem.
-  for(i; i != subproblems.end(); i++){
-    partials[division] = divide_conquer(seq, *i, 
-        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
-        std::forward<Combiner>(combine_op));
-  }
-
-  Output out = internal_divide_conquer(ex, *subproblems.begin(),  
-      std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
-      std::forward<Combiner>(combine_op), num_threads);
-
-  g.wait();
-
-  for (auto && p : partials) { out = combine_op(out,p); }
-
-  return out;
-}
 
 /**
 \addtogroup divide_conquer_pattern
@@ -111,72 +51,13 @@ parallel execution.
 \param combiner_op Combiner operation.
 */
 template <typename Input, typename Divider, typename Solver, typename Combiner>
-typename std::result_of<Solver(Input)>::type 
-divide_conquer(parallel_execution_tbb & ex, 
-                   Input & input,
-                   Divider && divide_op, Solver && solve_op, 
-                   Combiner && combine_op) 
+auto divide_conquer(const parallel_execution_tbb & ex, 
+                    const Input & input,
+                    Divider && divide_op, Solver && solve_op, 
+                    Combiner && combine_op) 
 {
-  // Sequential execution fo internal implementation
-  sequential_execution seq;
-
-  std::atomic<int> num_threads{ex.concurrency_degree()-1};
-
-  if (num_threads.load()<=0) {
-    return divide_conquer(seq, input,  std::forward<Divider>(divide_op), 
+  return ex.divide_conquer(input, std::forward<Divider>(divide_op), 
       std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
-  }
-
-  auto subproblems = divide_op(input);
-  if (subproblems.size()<=1) {
-    return solve_op(input);
-  }
-
-  using Output = typename std::result_of<Solver(Input)>::type;
-  std::vector<Output> partials(subproblems.size()-1);
-  int division = 0;
-  tbb::task_group g;
-            
-  auto i = subproblems.begin()+1;
-  for (i ; i!=subproblems.end() && num_threads.load()>0; i++, division++) {
-    //THREAD
-    g.run(
-      [&ex, i, &partials, division, &divide_op, &solve_op, &combine_op, 
-       &num_threads]()
-      {
-        partials[division] = internal_divide_conquer(ex, *i, 
-            std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
-            std::forward<Combiner>(combine_op), num_threads);
-      }
-    );
-    num_threads--;
-    //END TRHEAD
-  }
-  for(i; i != subproblems.end(); i++){
-    partials[division] = divide_conquer(seq, *i, 
-        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
-        std::forward<Combiner>(combine_op));
-  }
-  //Main thread works on the first subproblem.
-
-  Output out; 
-  if (num_threads.load()>0) {
-    out = internal_divide_conquer(ex, *subproblems.begin(), 
-        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
-        std::forward<Combiner>(combine_op), num_threads);
-  }
-  else {
-    out = divide_conquer(seq, *subproblems.begin(),  
-        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
-        std::forward<Combiner>(combine_op));
-  } 
-
-  g.wait();
-
-  for (int i=0; i<partials.size(); i++){ 
-    out = combine_op(out , partials[i]);
-  }
-  return out;
 }
 
 /**

--- a/include/tbb/parallel_execution_tbb.h
+++ b/include/tbb/parallel_execution_tbb.h
@@ -194,6 +194,32 @@ public:
                StencilTransformer && transform_op,
                Neighbourhood && neighbour_op) const;
 
+  /**
+  \brief Invoke \ref md_divide-conquer.
+  \tparam Input Type used for the input problem.
+  \tparam Divider Callable type for the divider operation.
+  \tparam Solver Callable type for the solver operation.
+  \tparam Combiner Callable type for the combiner operation.
+  \param ex Sequential execution policy object.
+  \param input Input problem to be solved.
+  \param divider_op Divider operation.
+  \param solver_op Solver operation.
+  \param combine_op Combiner operation.
+  */
+  template <typename Input, typename Divider, typename Solver, typename Combiner>
+  auto divide_conquer(const Input & input, 
+                      Divider && divide_op, 
+                      Solver && solve_op, 
+                      Combiner && combine_op) const; 
+
+private:
+
+  template <typename Input, typename Divider, typename Solver, typename Combiner>
+  auto divide_conquer(const Input & input, 
+                      Divider && divide_op, 
+                      Solver && solve_op, 
+                      Combiner && combine_op,
+                      std::atomic<int> & num_threads) const; 
 private:
 
   constexpr static int default_concurrency_degree = 4;
@@ -318,6 +344,72 @@ void parallel_execution_tbb::stencil(
       std::distance(std::get<0>(chunk_firsts), chunk_last), delta);
 
   g.wait();
+}
+
+template <typename Input, typename Divider, typename Solver, typename Combiner>
+auto parallel_execution_tbb::divide_conquer(
+    const Input & input, 
+    Divider && divide_op, 
+    Solver && solve_op, 
+    Combiner && combine_op) const
+{
+  std::atomic<int> num_threads{concurrency_degree_-1};
+  return divide_conquer(input, std::forward<Divider>(divide_op), 
+        std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op),
+        num_threads);
+}
+
+template <typename Input, typename Divider, typename Solver, typename Combiner>
+auto parallel_execution_tbb::divide_conquer(
+    const Input & input, 
+    Divider && divide_op, 
+    Solver && solve_op, 
+    Combiner && combine_op,
+    std::atomic<int> & num_threads) const
+{
+  constexpr sequential_execution seq;
+
+  if (num_threads.load()<=0) {
+    return seq.divide_conquer(input, std::forward<Divider>(divide_op), 
+        std::forward<Solver>(solve_op), std::forward<Combiner>(combine_op));
+  }
+
+  auto subproblems = divide_op(input);
+
+  if (subproblems.size()<=1) {
+    return solve_op(input);
+  }
+
+  using subresult_type = std::decay_t<typename std::result_of<Solver(Input)>::type>;
+  std::vector<subresult_type> partials(subproblems.size()-1);
+  int division = 0;
+
+  tbb::task_group g;
+  auto i = subproblems.begin()+1;
+  while (i!=subproblems.end() && num_threads.load()>0) {
+    g.run([&,this,it=i++,div=division++]() {
+        partials[div] = this->divide_conquer(*it, 
+            std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+            std::forward<Combiner>(combine_op), num_threads);
+    });
+    num_threads--;
+  }
+
+  //Main thread works on the first subproblem.
+  while (i != subproblems.end()){
+    partials[division] = seq.divide_conquer(*i++, 
+        std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+        std::forward<Combiner>(combine_op));
+  }
+
+  auto out = divide_conquer(*subproblems.begin(),  
+      std::forward<Divider>(divide_op), std::forward<Solver>(solve_op), 
+      std::forward<Combiner>(combine_op), num_threads);
+
+  g.wait();
+
+  return seq.reduce(partials.begin(), partials.size(), out, 
+      std::forward<Combiner>(combine_op));
 }
 
 /**


### PR DESCRIPTION
Revised divide/conquer pattern:
+ Moved functionality to execution types.
+ Made input value to be forwarding reference.
+ Native parallel execution implementation of divide_conquer now uses a worker_pool.