### PR TITLE
Added support for context

### DIFF
--- a/include/common/context.h
+++ b/include/common/context.h
@@ -25,9 +25,12 @@
 namespace grppi {
 
 /**
-\brief Representation of farm pattern.
-Represents a farm of n replicas from a transformer.
-\tparam Transformer Callable type for the farm transformer.
+\brief Representation of a context pattern.
+Represents a context that uses a given policy to run a transformer.
+This pattern is intended to switch between execution policies 
+in a pattern composition.
+\tparam ExecutionPolicy Execution policy type for the context.
+\tparam Transformer Callable type for the context transformer.
 */
 template <typename ExecutionPolicy, typename Transformer>
 class context_t {
@@ -63,7 +66,7 @@ public:
   }
 
   /**
-  \brief Invokes the trasnformer of the farm over a data item.
+  \brief Invokes the trasnformer of the context over a data item.
   */
   template <typename I>
   auto operator()(I && item) const {
@@ -71,7 +74,6 @@ public:
   }
 
 private:
-  int cardinality_;
   Transformer transformer_;
   ExecutionPolicy& execution_policy_;
 };

--- a/include/common/context.h
+++ b/include/common/context.h
@@ -1,0 +1,97 @@
+/**
+* @version		GrPPI v0.3
+* @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
+* @license		GNU/GPL, see LICENSE.txt
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You have received a copy of the GNU General Public License in LICENSE.txt
+* also available in <http://www.gnu.org/licenses/gpl.html>.
+*
+* See COPYRIGHT.txt for copyright notices and details.
+*/
+#ifndef GRPPI_COMMON_CONTEXT_H
+#define GRPPI_COMMON_CONTEXT_H
+
+#include <type_traits>
+
+namespace grppi {
+
+/**
+\brief Representation of farm pattern.
+Represents a farm of n replicas from a transformer.
+\tparam Transformer Callable type for the farm transformer.
+*/
+template <typename ExecutionPolicy, typename Transformer>
+class context_t {
+public:
+
+  using transformer_type = Transformer;
+  using execution_policy_type = ExecutionPolicy;
+
+  /**
+  \brief Constructs a context with a execution policy and a transformer.
+  \param e Context to run the transformer function.
+  \param t Transformer to be run.
+  */
+  context_t(ExecutionPolicy & e, Transformer && t) noexcept :
+    execution_policy_{e}, transformer_{t}
+  {}
+
+  /**
+  \brief Return the execution policy used in the context.
+  \return The execution policy. 
+  */
+  ExecutionPolicy & execution_policy(){
+    return execution_policy_;
+  }
+  
+
+  /**
+  \brief Return the transformer function.
+  \return The transformer function. 
+  */
+  Transformer & transformer(){
+    return transformer_;
+  }
+
+  /**
+  \brief Invokes the trasnformer of the farm over a data item.
+  */
+  template <typename I>
+  auto operator()(I && item) const {
+    return transformer_(std::forward<I>(item));
+  }
+
+private:
+  int cardinality_;
+  Transformer transformer_;
+  ExecutionPolicy& execution_policy_;
+};
+
+namespace internal {
+
+template<typename T>
+struct is_context : std::false_type {};
+
+template<typename E, typename T>
+struct is_context<context_t<E,T>> : std::true_type {};
+
+} // namespace internal
+
+template <typename T>
+static constexpr bool is_context = internal::is_context<std::decay_t<T>>();
+
+template <typename T>
+using requires_context = typename std::enable_if_t<is_context<T>, int>;
+
+}
+
+#endif

--- a/include/common/patterns.h
+++ b/include/common/patterns.h
@@ -1,4 +1,4 @@
-/**
+/*
 * @version		GrPPI v0.2
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
@@ -30,6 +30,7 @@
 #include "pipeline_pattern.h"
 #include "reduce_pattern.h"
 #include "iteration_pattern.h"
+#include "context.h"
 
 namespace grppi{
 
@@ -81,7 +82,8 @@ constexpr bool is_no_pattern =
   !is_filter<T> && 
   !is_pipeline<T> &&
   !is_reduce<T> &&
-  !is_iteration<T>;
+  !is_iteration<T>&&
+  !is_context<T>;
 
 template <typename T>
 constexpr bool is_pattern = !is_no_pattern<T>;

--- a/include/context.h
+++ b/include/context.h
@@ -1,5 +1,5 @@
 /**
-* @version		GrPPI v0.2
+* @version		GrPPI v0.3
 * @copyright		Copyright (C) 2017 Universidad Carlos III de Madrid. All rights reserved.
 * @license		GNU/GPL, see LICENSE.txt
 * This program is free software: you can redistribute it and/or modify
@@ -18,48 +18,39 @@
 * See COPYRIGHT.txt for copyright notices and details.
 */
 
-#ifndef GRPPI_GRPPI_H
-#define GRPPI_GRPPI_H
+#ifndef GRPPI_CONTEXT_H
+#define GRPPI_CONTEXT_H
 
-// Includes for data parallel patterns
-#include "map.h"
-#include "mapreduce.h"
-#include "reduce.h"
-#include "stencil.h"
+#include "common/context.h"
 
 namespace grppi {
 
 /** 
-\defgroup data_patterns Data parallel patterns
-\brief Patterns for data parallel processing.
+\addtogroup stream_patterns
+@{
+\defgroup context Context
+\brief Interface for defining a new \ref md_context to run a given function or pattern.
+@{
 */
 
-}
-
-// Includes for task patterns
-#include "divideconquer.h"
-
-namespace grppi {
-
-/** 
-\defgroup task_patterns Task parallel patterns
-\brief Patterns for task parallel processing.
+/**
+\brief Define a new \ref md_context on a data stream 
+that can be composed in other streaming patterns.
+\tparam Execution Execution policy type.
+\tparam Transformer Callable type for the transformation operation.
+\param ex Execution policy object.
+\param transform_op Transformer operation.
 */
+template <typename ExecutionPolicy, typename Transformer>
+auto context(ExecutionPolicy & ex, Transformer && transform_op)
+{
+   return context_t<ExecutionPolicy,Transformer>{ex,
+       std::forward<Transformer>(transform_op)};
 }
 
-// Includes for streaming patterns
-#include "context.h"
-#include "farm.h"
-#include "pipeline.h"
-#include "stream_filter.h"
-#include "stream_iteration.h"
-#include "stream_reduce.h"
-
-namespace grppi {
-
-/** 
-\defgroup stream_patterns Streaming patterns
-\brief Patterns for data stream processing.
+/**
+@}
+@}
 */
 
 }

--- a/include/context.h
+++ b/include/context.h
@@ -42,7 +42,7 @@ that can be composed in other streaming patterns.
 \param transform_op Transformer operation.
 */
 template <typename ExecutionPolicy, typename Transformer>
-auto context(ExecutionPolicy & ex, Transformer && transform_op)
+auto run_with(ExecutionPolicy & ex, Transformer && transform_op)
 {
    return context_t<ExecutionPolicy,Transformer>{ex,
        std::forward<Transformer>(transform_op)};

--- a/include/native/parallel_execution_native.h
+++ b/include/native/parallel_execution_native.h
@@ -367,6 +367,23 @@ public:
   void pipeline(Generator && generate_op, 
                 Transformers && ... transform_ops) const;
 
+  /**
+  \brief Invoke \ref md_pipeline comming from another context
+  that uses mpmc_queues as communication channels.
+  \tparam InputType Type of the input stream.
+  \tparam Transformers Callable types for the transformers in the pipeline.
+  \tparam InputType Type of the output stream.
+  \param input_queue Input stream communicator.
+  \param transform_ops Transformer operations.
+  \param output_queue Input stream communicator.
+  */
+  template <typename InputType, typename Transformer, typename OutputType>
+  void pipeline(mpmc_queue<InputType> & input_queue, Transformer && transform_op,
+                mpmc_queue<OutputType> &output_queue) const
+  {
+    do_pipeline(input_queue, std::forward<Transformer>(transform_op), output_queue);
+  }
+
 private:
 
   template <typename Input, typename Divider, typename Solver, typename Combiner>
@@ -392,6 +409,7 @@ private:
   template <typename T>
   void do_pipeline(mpmc_queue<T> & in_q) const {}
 
+
   template <typename Queue, typename Transformer, typename ... OtherTransformers,
             requires_no_pattern<Transformer> = 0>
   void do_pipeline(Queue & input_queue, Transformer && transform_op,
@@ -411,6 +429,24 @@ private:
             requires_farm<Farm<FarmTransformer>> = 0>
   void do_pipeline( Queue & input_queue, 
       Farm<FarmTransformer> && farm_obj) const;
+
+  template <typename Queue, typename Execution, typename Transformer, 
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  void do_pipeline(Queue & input_queue, Context<Execution,Transformer> && context_op, 
+       OtherTransformers &&... other_ops) const;
+
+  template <typename Queue, typename Execution, typename Transformer, 
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  void do_pipeline(Queue & input_queue, Context<Execution,Transformer> & context_op, 
+       OtherTransformers &&... other_ops) const
+  {
+    do_pipeline(input_queue, std::move(context_op),
+      std::forward<OtherTransformers>(other_ops)...);
+  }
 
   template <typename Queue, typename FarmTransformer, 
             template <typename> class Farm,
@@ -999,6 +1035,39 @@ void parallel_execution_native::do_pipeline(
   workers.launch_tasks(*this, farm_task, ntasks);  
   workers.wait();
 }
+
+
+template <typename Queue, typename Execution, typename Transformer,
+          template <typename, typename> class Context,
+          typename ... OtherTransformers,
+          requires_context<Context<Execution,Transformer>> = 0>
+void parallel_execution_native::do_pipeline(Queue & input_queue, 
+    Context<Execution,Transformer> && context_op,
+    OtherTransformers &&... other_ops) const 
+{
+  using namespace std;
+  using namespace experimental;
+
+  using input_item_type = typename Queue::value_type;
+  using input_item_value_type = typename input_item_type::first_type::value_type;
+
+  using output_type = typename stage_return_type<input_item_value_type, Transformer>::type;
+  using output_optional_type = experimental::optional<output_type>;
+  using output_item_type = pair <output_optional_type, long> ;
+
+  decltype(auto) output_queue =
+    get_output_queue<output_item_type>(other_ops...);
+  
+  auto context_task = [&](int nt) {
+    context_op.execution_policy().pipeline(input_queue, context_op.transformer(), output_queue);
+  };
+  worker_pool workers{1};
+  workers.launch_tasks(*this, context_task, 1);
+  do_pipeline(output_queue,
+      forward<OtherTransformers>(other_ops)... );
+  workers.wait();
+}
+
 
 template <typename Queue, typename FarmTransformer, 
           template <typename> class Farm,

--- a/include/omp/parallel_execution_omp.h
+++ b/include/omp/parallel_execution_omp.h
@@ -269,6 +269,23 @@ public:
   template <typename Generator, typename ... Transformers>
   void pipeline(Generator && generate_op, 
                 Transformers && ... transform_op) const;
+  
+  /**
+  \brief Invoke \ref md_pipeline comming from another context
+  that uses mpmc_queues as communication channels.
+  \tparam InputType Type of the input stream.
+  \tparam Transformers Callable types for the transformers in the pipeline.
+  \tparam InputType Type of the output stream.
+  \param input_queue Input stream communicator.
+  \param transform_ops Transformer operations.
+  \param output_queue Input stream communicator.
+  */
+  template <typename InputType, typename Transformer, typename OutputType>
+  void pipeline(mpmc_queue<InputType> & input_queue, Transformer && transform_op,
+                mpmc_queue<OutputType> &output_queue) const
+  {
+    do_pipeline(input_queue, std::forward<Transformer>(transform_op), output_queue);
+  }
 
 private:
 
@@ -295,11 +312,28 @@ private:
   template <typename T>
   void do_pipeline(mpmc_queue<T> & in_q) const {}
 
-
   template <typename Queue, typename Transformer, typename ... OtherTransformers,
             requires_no_pattern<Transformer> = 0>
   void do_pipeline(Queue & input_queue, Transformer && transform_op,
     OtherTransformers && ... other_ops) const;
+
+  template <typename Queue, typename Execution, typename Transformer,
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  void do_pipeline(Queue & input_queue, Context<Execution,Transformer> && context_op,
+       OtherTransformers &&... other_ops) const;
+
+  template <typename Queue, typename Execution, typename Transformer,
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  void do_pipeline(Queue & input_queue, Context<Execution,Transformer> & context_op,
+       OtherTransformers &&... other_ops) const
+  {
+    do_pipeline(input_queue, std::move(context_op),
+      std::forward<OtherTransformers>(other_ops)...);
+  }
 
   template <typename Queue, typename FarmTransformer,
             template <typename> class Farm,
@@ -867,6 +901,38 @@ void parallel_execution_omp::do_pipeline(Inqueue & input_queue, Transformer && t
     auto out = output_item_value_type{transform_op(*item.first)};
     output_queue.push(make_pair(out,item.second)) ;
   }
+}
+
+
+template <typename Queue, typename Execution, typename Transformer,
+          template <typename, typename> class Context,
+          typename ... OtherTransformers,
+          requires_context<Context<Execution,Transformer>> = 0>
+void parallel_execution_omp::do_pipeline(Queue & input_queue,
+    Context<Execution,Transformer> && context_op,
+    OtherTransformers &&... other_ops) const
+{
+  using namespace std;
+  using namespace experimental;
+
+  using input_item_type = typename Queue::value_type;
+  using input_item_value_type = typename input_item_type::first_type::value_type;
+
+  using output_type = typename stage_return_type<input_item_value_type, Transformer>::type;
+  using output_optional_type = experimental::optional<output_type>;
+  using output_item_type = pair <output_optional_type, long> ;
+
+  decltype(auto) output_queue =
+    get_output_queue<output_item_type>(other_ops...);
+  
+  #pragma omp task shared(input_queue,context_op,output_queue)
+  {
+    context_op.execution_policy().pipeline(input_queue, context_op.transformer(), output_queue);
+  }
+
+  do_pipeline(output_queue,
+      forward<OtherTransformers>(other_ops)... );
+  #pragma omp taskwait
 }
 
 template <typename Queue, typename Transformer, typename ... OtherTransformers,

--- a/include/seq/sequential_execution.h
+++ b/include/seq/sequential_execution.h
@@ -21,6 +21,7 @@
 #ifndef GRPPI_SEQ_SEQUENTIAL_EXECUTION_H
 #define GRPPI_SEQ_SEQUENTIAL_EXECUTION_H
 
+#include "../common/mpmc_queue.h"
 #include "../common/iterator.h"
 #include "../common/callable_traits.h"
 #include "../common/execution_traits.h"
@@ -30,7 +31,7 @@
 #include <type_traits>
 #include <tuple>
 #include <iterator>
-
+//#include <experimental/optional>
 
 namespace grppi {
 
@@ -185,6 +186,35 @@ public:
   void pipeline(Generator && generate_op, 
                 Transformers && ... transform_op) const;
 
+    /**
+  \brief Invoke \ref md_pipeline comming from another context
+  that uses mpmc_queues as communication channels.
+  \tparam InputType Type of the input stream.
+  \tparam Transformers Callable types for the transformers in the pipeline.
+  \tparam InputType Type of the output stream.
+  \param input_queue Input stream communicator.
+  \param transform_ops Transformer operations.
+  \param output_queue Input stream communicator.
+  */
+  template <typename InputType, typename Transformer, typename OutputType>
+  void pipeline(mpmc_queue<InputType> & input_queue, Transformer && transform_op,
+                mpmc_queue<OutputType> & output_queue) const
+  {
+    using namespace std;
+    using optional_output_type = typename OutputType::first_type;
+    for(;;){
+      auto item = input_queue.pop();
+      if(!item.first) break;
+      do_pipeline(*item.first, std::forward<Transformer>(transform_op),
+        [&](auto output_item) {
+          output_queue.push( make_pair(optional_output_type{output_item}, item.second) );
+        }
+      );
+    }
+    output_queue.push( make_pair(optional_output_type{}, -1) );
+  }
+
+
 private:
 
   template <typename Item, typename Consumer,
@@ -208,6 +238,29 @@ private:
             template <typename> class Farm,
             requires_farm<Farm<FarmTransformer>> = 0>
   void do_pipeline(Item && item, Farm<FarmTransformer> && farm_obj) const;
+
+  template <typename Item, typename Execution, typename Transformer,
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  void do_pipeline(Item && item, Context<Execution,Transformer> && context_op,
+       OtherTransformers &&... other_ops) const
+  {
+     do_pipeline(item, std::forward<Transformer>(context_op.transformer()), 
+       std::forward<OtherTransformers>(other_ops)...);
+  }
+
+  template <typename Item, typename Execution, typename Transformer,
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  void do_pipeline(Item && item, Context<Execution,Transformer> & context_op,
+       OtherTransformers &&... other_ops) const
+  {
+    do_pipeline(item, std::move(context_op),
+      std::forward<OtherTransformers>(other_ops)...);
+  }
+
 
   template <typename Item, typename FarmTransformer,
             template <typename> class Farm,

--- a/include/tbb/parallel_execution_tbb.h
+++ b/include/tbb/parallel_execution_tbb.h
@@ -226,6 +226,25 @@ public:
   void pipeline(Generator && generate_op, 
                 Transformers && ... transform_op) const;
 
+  /**
+  \brief Invoke \ref md_pipeline comming from another context
+  that uses mpmc_queues as communication channels.
+  \tparam InputType Type of the input stream.
+  \tparam Transformers Callable types for the transformers in the pipeline.
+  \tparam InputType Type of the output stream.
+  \param input_queue Input stream communicator.
+  \param transform_ops Transformer operations.
+  \param output_queue Input stream communicator.
+  */
+  template <typename InputType, typename Transformer, typename OutputType>
+  void pipeline(mpmc_queue<InputType> & input_queue, Transformer && transform_op,
+                mpmc_queue<OutputType> & output_queue) const
+  {
+    sequential_execution seq{};
+    seq.pipeline(input_queue, std::forward<Transformer>(transform_op), output_queue);
+  }
+
+
 private:
 
   template <typename Input, typename Divider, typename Solver, typename Combiner>
@@ -256,6 +275,29 @@ private:
             template <typename> class Farm,
             requires_farm<Farm<FarmTransformer>> = 0>
   auto make_filter(Farm<FarmTransformer> && farm_obj) const;
+
+  template <typename Input, typename Execution, typename Transformer,
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  auto make_filter(Context<Execution,Transformer> && context_op,
+       OtherTransformers &&... other_ops) const
+  {
+     return this->template make_filter<Input>(std::forward<Transformer>(context_op.transformer()),
+       std::forward<OtherTransformers>(other_ops)...);
+  }
+
+  template <typename Input, typename Execution, typename Transformer,
+            template <typename, typename> class Context,
+            typename ... OtherTransformers,
+            requires_context<Context<Execution,Transformer>> = 0>
+  auto make_filter(Context<Execution,Transformer> & context_op,
+       OtherTransformers &&... other_ops) const
+  {
+    return this->template make_filter<Input>(std::move(context_op),
+      std::forward<OtherTransformers>(other_ops)...);
+  }
+
 
   template <typename Input, typename FarmTransformer, 
             template <typename> class Farm,


### PR DESCRIPTION
Added support for context.

Current version allows to switch context between omp, native and sequential back-ends. Using TBB as back-end uses sequential implementation.

