### PR TITLE
Clang Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ message( STATUS "CMAKE_CXX_COMPILER_ID: " ${CMAKE_CXX_COMPILER_ID} )
 # Set specific options depending on compiler
 if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
 
-    if(NOT(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 3.4.0))
+    if(NOT(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 3.9.0))
         message( FATAL_ERROR "Clang version " ${CMAKE_CXX_COMPILER_VERSION} " not supported. Upgrade to 3.4 or above.")
     else()
         message( STATUS "C++ Compiler is Clang" )
@@ -77,7 +77,7 @@ if( GRPPI_OMP_ENABLE )
 endif( GRPPI_OMP_ENABLE )
 
 #FastFlow library
-option( GRPPI_FF_ENABLE "Require FastFlow library" ON )
+option( GRPPI_FF_ENABLE "Require FastFlow library" OFF )
 message( STATUS "FastFlow: " ${GRPPI_FF_ENABLE})
 if(GRPPI_FF_ENABLE)
   find_package(FF)
@@ -103,7 +103,7 @@ endif( GRPPI_EXAMPLE_APPLICATIONS_ENABLE )
 
 # Unit Tests
 enable_testing()
-option( GRPPI_UNIT_TEST_ENABLE "Unit tests" OFF )
+option( GRPPI_UNIT_TEST_ENABLE "Unit tests" ON )
 if( GRPPI_UNIT_TEST_ENABLE )
     add_subdirectory(unit_tests)
 endif( GRPPI_UNIT_TEST_ENABLE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if( GRPPI_OMP_ENABLE )
 endif( GRPPI_OMP_ENABLE )
 
 #FastFlow library
-option( GRPPI_FF_ENABLE "Require FastFlow library" OFF )
+option( GRPPI_FF_ENABLE "Require FastFlow library" ON )
 message( STATUS "FastFlow: " ${GRPPI_FF_ENABLE})
 if(GRPPI_FF_ENABLE)
   find_package(FF)

--- a/include/native/parallel_execution_native.h
+++ b/include/native/parallel_execution_native.h
@@ -995,7 +995,7 @@ auto parallel_execution_native::divide_conquer(
       std::forward<subresult_type>(subresult), std::forward<Combiner>(combine_op));
 }
 template <typename Queue, typename Consumer,
-          requires_no_pattern<Consumer> = 0>
+          requires_no_pattern<Consumer>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue, 
     Consumer && consume_op) const
@@ -1050,7 +1050,7 @@ void parallel_execution_native::do_pipeline(
 
 
 template <typename Inqueue, typename Transformer, typename output_type,
-            requires_no_pattern<Transformer> = 0>
+            requires_no_pattern<Transformer>>
 void parallel_execution_native::do_pipeline(Inqueue & input_queue, Transformer && transform_op,
       mpmc_queue<output_type> & output_queue) const
 {
@@ -1074,7 +1074,7 @@ void parallel_execution_native::do_pipeline(Inqueue & input_queue, Transformer &
 
 template <typename Queue, typename Transformer, 
           typename ... OtherTransformers,
-          requires_no_pattern<Transformer> =0>
+          requires_no_pattern<Transformer>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue, 
     Transformer && transform_op,
@@ -1113,7 +1113,7 @@ void parallel_execution_native::do_pipeline(
 
 template <typename Queue, typename FarmTransformer,
           template <typename> class Farm,
-          requires_farm<Farm<FarmTransformer>> =0>
+          requires_farm<Farm<FarmTransformer>>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue, 
     Farm<FarmTransformer> && farm_obj) const
@@ -1146,7 +1146,7 @@ void parallel_execution_native::do_pipeline(
 template <typename Queue, typename Execution, typename Transformer,
           template <typename, typename> class Context,
           typename ... OtherTransformers,
-          requires_context<Context<Execution,Transformer>> = 0>
+          requires_context<Context<Execution,Transformer>>>
 void parallel_execution_native::do_pipeline(Queue & input_queue, 
     Context<Execution,Transformer> && context_op,
     OtherTransformers &&... other_ops) const 
@@ -1182,7 +1182,7 @@ void parallel_execution_native::do_pipeline(Queue & input_queue,
 template <typename Queue, typename FarmTransformer, 
           template <typename> class Farm,
           typename ... OtherTransformers,
-          requires_farm<Farm<FarmTransformer>> =0>
+          requires_farm<Farm<FarmTransformer>>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue, 
     Farm<FarmTransformer> && farm_obj,
@@ -1225,7 +1225,7 @@ void parallel_execution_native::do_pipeline(
 template <typename Queue, typename Predicate, 
           template <typename> class Filter,
           typename ... OtherTransformers,
-          requires_filter<Filter<Predicate>> =0>
+          requires_filter<Filter<Predicate>>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue, 
     Filter<Predicate> && filter_obj,
@@ -1323,7 +1323,7 @@ void parallel_execution_native::do_pipeline(
 template <typename Queue, typename Combiner, typename Identity,
           template <typename C, typename I> class Reduce,
           typename ... OtherTransformers,
-          requires_reduce<Reduce<Combiner,Identity>> = 0>
+          requires_reduce<Reduce<Combiner,Identity>>>
 void parallel_execution_native::do_pipeline(
     Queue && input_queue, 
     Reduce<Combiner,Identity> && reduce_obj,
@@ -1362,8 +1362,8 @@ void parallel_execution_native::do_pipeline(
 template <typename Queue, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> =0,
-          requires_no_pattern<Transformer> =0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_no_pattern<Transformer>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue, 
     Iteration<Transformer,Predicate> && iteration_obj,
@@ -1413,8 +1413,8 @@ void parallel_execution_native::do_pipeline(
 template <typename Queue, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> =0,
-          requires_pipeline<Transformer> =0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_pipeline<Transformer>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue, 
     Iteration<Transformer,Predicate> && iteration_obj,
@@ -1426,7 +1426,7 @@ void parallel_execution_native::do_pipeline(
 
 template <typename Queue, typename ... Transformers,
           template <typename...> class Pipeline,
-          requires_pipeline<Pipeline<Transformers...>> = 0>
+          requires_pipeline<Pipeline<Transformers...>>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue,
     Pipeline<Transformers...> && pipeline_obj) const
@@ -1440,7 +1440,7 @@ void parallel_execution_native::do_pipeline(
 template <typename Queue, typename ... Transformers,
           template <typename...> class Pipeline,
           typename ... OtherTransformers,
-          requires_pipeline<Pipeline<Transformers...>> = 0>
+          requires_pipeline<Pipeline<Transformers...>>>
 void parallel_execution_native::do_pipeline(
     Queue & input_queue,
     Pipeline<Transformers...> && pipeline_obj,

--- a/include/omp/parallel_execution_omp.h
+++ b/include/omp/parallel_execution_omp.h
@@ -963,7 +963,7 @@ auto parallel_execution_omp::divide_conquer(
 }
 
 template <typename Queue, typename Consumer,
-          requires_no_pattern<Consumer> =0>
+          requires_no_pattern<Consumer>>
 void parallel_execution_omp::do_pipeline(Queue & input_queue, Consumer && consume_op) const
 {
   using namespace std;
@@ -1013,7 +1013,7 @@ void parallel_execution_omp::do_pipeline(Queue & input_queue, Consumer && consum
 
 
 template <typename Inqueue, typename Transformer, typename output_type,
-            requires_no_pattern<Transformer> = 0>
+            requires_no_pattern<Transformer>>
 void parallel_execution_omp::do_pipeline(Inqueue & input_queue, Transformer && transform_op,
       mpmc_queue<output_type> & output_queue) const
 {
@@ -1037,7 +1037,7 @@ void parallel_execution_omp::do_pipeline(Inqueue & input_queue, Transformer && t
 template <typename Queue, typename Execution, typename Transformer,
           template <typename, typename> class Context,
           typename ... OtherTransformers,
-          requires_context<Context<Execution,Transformer>> = 0>
+          requires_context<Context<Execution,Transformer>>>
 void parallel_execution_omp::do_pipeline(Queue & input_queue,
     Context<Execution,Transformer> && context_op,
     OtherTransformers &&... other_ops) const
@@ -1067,7 +1067,7 @@ void parallel_execution_omp::do_pipeline(Queue & input_queue,
 }
 
 template <typename Queue, typename Transformer, typename ... OtherTransformers,
-          requires_no_pattern<Transformer> =0>
+          requires_no_pattern<Transformer>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue, 
     Transformer && transform_op,
@@ -1100,7 +1100,7 @@ void parallel_execution_omp::do_pipeline(
 
 template <typename Queue, typename FarmTransformer,
           template <typename> class Farm,
-          requires_farm<Farm<FarmTransformer>> =0>
+          requires_farm<Farm<FarmTransformer>>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue, 
     Farm<FarmTransformer> && farm_obj) const
@@ -1127,7 +1127,7 @@ void parallel_execution_omp::do_pipeline(
 template <typename Queue, typename FarmTransformer, 
           template <typename> class Farm,
           typename ... OtherTransformers,
-          requires_farm<Farm<FarmTransformer>> =0>
+          requires_farm<Farm<FarmTransformer>>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue, 
     Farm<FarmTransformer> && farm_obj,
@@ -1168,7 +1168,7 @@ void parallel_execution_omp::do_pipeline(
 
 template <typename Queue, typename Predicate,
           template <typename> class Filter,
-          requires_filter<Filter<Predicate>> = 0>
+          requires_filter<Filter<Predicate>>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue, 
     Filter<Predicate> && filter_obj) const
@@ -1178,7 +1178,7 @@ void parallel_execution_omp::do_pipeline(
 template <typename Queue, typename Predicate, 
           template <typename> class Filter,
           typename ... OtherTransformers,
-          requires_filter<Filter<Predicate>> =0>
+          requires_filter<Filter<Predicate>>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue, 
     Filter<Predicate> && filter_obj,
@@ -1297,7 +1297,7 @@ void parallel_execution_omp::do_pipeline(
 template <typename Queue, typename Combiner, typename Identity,
           template <typename C, typename I> class Reduce,
           typename ... OtherTransformers,
-          requires_reduce<Reduce<Combiner,Identity>> = 0>
+          requires_reduce<Reduce<Combiner,Identity>>>
 void parallel_execution_omp::do_pipeline(
     Queue && input_queue, 
     Reduce<Combiner,Identity> && reduce_obj,
@@ -1341,8 +1341,8 @@ void parallel_execution_omp::do_pipeline(
 template <typename Queue, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> =0,
-          requires_no_pattern<Transformer> =0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_no_pattern<Transformer>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue, 
     Iteration<Transformer,Predicate> && iteration_obj,
@@ -1403,8 +1403,8 @@ void parallel_execution_omp::do_pipeline(
 template <typename Queue, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> =0,
-          requires_pipeline<Transformer> =0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_pipeline<Transformer>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue, 
     Iteration<Transformer,Predicate> && iteration_obj,
@@ -1416,7 +1416,7 @@ void parallel_execution_omp::do_pipeline(
 template <typename Queue, typename ... Transformers,
           template <typename...> class Pipeline,
           typename ... OtherTransformers,
-          requires_pipeline<Pipeline<Transformers...>> = 0>
+          requires_pipeline<Pipeline<Transformers...>>>
 void parallel_execution_omp::do_pipeline(
     Queue & input_queue,
     Pipeline<Transformers...> && pipeline_obj,

--- a/include/seq/sequential_execution.h
+++ b/include/seq/sequential_execution.h
@@ -577,7 +577,7 @@ void sequential_execution::pipeline(
 }
 
 template <typename Item, typename Consumer,
-          requires_no_pattern<Consumer> = 0>
+          requires_no_pattern<Consumer>>
 void sequential_execution::do_pipeline(
     Item && item,
     Consumer && consume_op) const
@@ -586,7 +586,7 @@ void sequential_execution::do_pipeline(
 }
 
 template <typename Item, typename Transformer, typename ... OtherTransformers,
-            requires_no_pattern<Transformer> = 0>
+            requires_no_pattern<Transformer>>
 void sequential_execution::do_pipeline(
     Item && item,
     Transformer && transform_op,
@@ -601,7 +601,7 @@ void sequential_execution::do_pipeline(
 
 template <typename Item, typename FarmTransformer,
           template <typename> class Farm,
-          requires_farm<Farm<FarmTransformer>> = 0>
+          requires_farm<Farm<FarmTransformer>>>
 void sequential_execution::do_pipeline(
     Item && item, 
     Farm<FarmTransformer> && farm_obj) const
@@ -612,7 +612,7 @@ void sequential_execution::do_pipeline(
 template <typename Item, typename FarmTransformer,
           template <typename> class Farm,
           typename... OtherTransformers,
-          requires_farm<Farm<FarmTransformer>> = 0>
+          requires_farm<Farm<FarmTransformer>>>
 void sequential_execution::do_pipeline(
     Item && item, 
     Farm<FarmTransformer> && farm_obj,
@@ -627,7 +627,7 @@ void sequential_execution::do_pipeline(
 template <typename Item, typename Predicate,
           template <typename> class Filter,
           typename ... OtherTransformers,
-          requires_filter<Filter<Predicate>> = 0>
+          requires_filter<Filter<Predicate>>>
 void sequential_execution::do_pipeline(
     Item && item, 
     Filter<Predicate> && filter_obj,
@@ -642,7 +642,7 @@ void sequential_execution::do_pipeline(
 template <typename Item, typename Combiner, typename Identity,
           template <typename C, typename I> class Reduce,
           typename ... OtherTransformers,
-          requires_reduce<Reduce<Combiner,Identity>> = 0>
+          requires_reduce<Reduce<Combiner,Identity>>>
 void sequential_execution::do_pipeline(
     Item && item, 
     Reduce<Combiner,Identity> && reduce_obj,
@@ -659,8 +659,8 @@ void sequential_execution::do_pipeline(
 template <typename Item, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> = 0,
-          requires_no_pattern<Transformer> = 0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_no_pattern<Transformer>>
 void sequential_execution::do_pipeline(
     Item && item, 
     Iteration<Transformer,Predicate> && iteration_obj, 
@@ -677,8 +677,8 @@ void sequential_execution::do_pipeline(
 template <typename Item, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> = 0,
-          requires_pipeline<Transformer> = 0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_pipeline<Transformer>>
 void sequential_execution::do_pipeline(
     Item && item, 
     Iteration<Transformer,Predicate> && iteration_obj, 
@@ -690,7 +690,7 @@ void sequential_execution::do_pipeline(
 template <typename Item, typename ... Transformers,
           template <typename...> class Pipeline,
           typename ... OtherTransformers,
-          requires_pipeline<Pipeline<Transformers...>> = 0>
+          requires_pipeline<Pipeline<Transformers...>>>
 void sequential_execution::do_pipeline(
     Item && item, 
     Pipeline<Transformers...> && pipeline_obj,

--- a/include/tbb/parallel_execution_tbb.h
+++ b/include/tbb/parallel_execution_tbb.h
@@ -809,7 +809,7 @@ auto parallel_execution_tbb::divide_conquer(
 }
 
 template <typename Input, typename Transformer,
-          requires_no_pattern<Transformer> = 0>
+          requires_no_pattern<Transformer>>
 auto parallel_execution_tbb::make_filter(
     Transformer && transform_op) const
 {
@@ -827,7 +827,7 @@ auto parallel_execution_tbb::make_filter(
 }
 
 template <typename Input, typename Transformer, typename ... OtherTransformers,
-          requires_no_pattern<Transformer> = 0>
+          requires_no_pattern<Transformer>>
 auto parallel_execution_tbb::make_filter(
     Transformer && transform_op,
     OtherTransformers && ... other_transform_ops) const
@@ -860,7 +860,7 @@ auto parallel_execution_tbb::make_filter(
 
 template <typename Input, typename FarmTransformer,
           template <typename> class Farm,
-          requires_farm<Farm<FarmTransformer>> = 0>
+          requires_farm<Farm<FarmTransformer>>>
 auto parallel_execution_tbb::make_filter(
     Farm<FarmTransformer> && farm_obj) const
 {
@@ -880,7 +880,7 @@ auto parallel_execution_tbb::make_filter(
 template <typename Input, typename FarmTransformer, 
           template <typename> class Farm,
           typename ... OtherTransformers,
-          requires_farm<Farm<FarmTransformer>> = 0>
+          requires_farm<Farm<FarmTransformer>>>
 auto parallel_execution_tbb::make_filter(
     Farm<FarmTransformer> && farm_obj,
     OtherTransformers && ... other_transform_ops) const
@@ -910,7 +910,7 @@ auto parallel_execution_tbb::make_filter(
 
 template <typename Input, typename Predicate,
           template <typename> class Filter,
-          requires_filter<Filter<Predicate>> = 0>
+          requires_filter<Filter<Predicate>>>
 auto parallel_execution_tbb::make_filter(
     Filter<Predicate> && farm_obj) const
 {
@@ -930,7 +930,7 @@ auto parallel_execution_tbb::make_filter(
 template <typename Input, typename Predicate, 
           template <typename> class Filter,
           typename ... OtherTransformers,
-          requires_filter<Filter<Predicate>> = 0>
+          requires_filter<Filter<Predicate>>>
 auto parallel_execution_tbb::make_filter(
     Filter<Predicate> && filter_obj,
     OtherTransformers && ... other_transform_ops) const
@@ -957,7 +957,7 @@ auto parallel_execution_tbb::make_filter(
 template <typename Input, typename Combiner, typename Identity,
           template <typename C, typename I> class Reduce,
           typename ... OtherTransformers,
-          requires_reduce<Reduce<Combiner,Identity>> = 0>
+          requires_reduce<Reduce<Combiner,Identity>>>
 auto parallel_execution_tbb::make_filter(
     Reduce<Combiner,Identity> && reduce_obj,
     OtherTransformers && ... other_transform_ops) const
@@ -988,8 +988,8 @@ auto parallel_execution_tbb::make_filter(
 template <typename Input, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> =0,
-          requires_no_pattern<Transformer> =0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_no_pattern<Transformer>>
 auto parallel_execution_tbb::make_filter(
     Iteration<Transformer,Predicate> && iteration_obj,
     OtherTransformers && ... other_transform_ops) const
@@ -1017,8 +1017,8 @@ auto parallel_execution_tbb::make_filter(
 template <typename Input, typename Transformer, typename Predicate,
           template <typename T, typename P> class Iteration,
           typename ... OtherTransformers,
-          requires_iteration<Iteration<Transformer,Predicate>> =0,
-          requires_pipeline<Transformer> =0>
+          requires_iteration<Iteration<Transformer,Predicate>>,
+          requires_pipeline<Transformer>>
 auto parallel_execution_tbb::make_filter(
     Iteration<Transformer,Predicate> && iteration_obj,
     OtherTransformers && ... other_transform_ops) const
@@ -1031,7 +1031,7 @@ auto parallel_execution_tbb::make_filter(
 template <typename Input, typename ... Transformers,
           template <typename...> class Pipeline,
           typename ... OtherTransformers,
-          requires_pipeline<Pipeline<Transformers...>> = 0>
+          requires_pipeline<Pipeline<Transformers...>>>
 auto parallel_execution_tbb::make_filter(
     Pipeline<Transformers...> && pipeline_obj,
     OtherTransformers && ... other_transform_ops) const


### PR DESCRIPTION
Pull Request to correct specific clang incompatibilities.
Fixes issue #320 

Credit to this 2 stack overflow questions:
 - https://stackoverflow.com/questions/7411515/why-does-c-require-a-user-provided-default-constructor-to-default-construct-a
 - https://stackoverflow.com/questions/14197436/c11-template-parameter-redefines-default-argument