### PR TITLE
Deprecated old divide/conquer interface

### DIFF
--- a/include/divideconquer.h
+++ b/include/divideconquer.h
@@ -49,6 +49,7 @@ namespace grppi {
 */
 template <typename Execution, typename Input, 
           typename Divider, typename Solver, typename Combiner>
+[[deprecated("Use newer divide_conquer with predicate arguemnt")]]
 auto divide_conquer(
     const Execution & ex, 
     Input && input, 

--- a/include/dyn/dynamic_execution.h
+++ b/include/dyn/dynamic_execution.h
@@ -138,6 +138,7 @@ public:
   \param combine_op Combiner operation.
   */
   template <typename Input, typename Divider, typename Solver, typename Combiner>
+  [[deprecated("Use new interface with predicate argument")]]
   auto divide_conquer(Input && input, 
                       Divider && divide_op, 
                       Solver && solve_op, 

--- a/include/native/parallel_execution_native.h
+++ b/include/native/parallel_execution_native.h
@@ -351,6 +351,7 @@ public:
   \param combine_op Combiner operation.
   */
   template <typename Input, typename Divider, typename Solver, typename Combiner>
+  [[deprecated("Use new interface with predicate argument")]]
   auto divide_conquer(Input && input, 
                       Divider && divide_op, 
                       Solver && solve_op, 

--- a/include/omp/parallel_execution_omp.h
+++ b/include/omp/parallel_execution_omp.h
@@ -255,6 +255,7 @@ public:
   \param combine_op Combiner operation.
   */
   template <typename Input, typename Divider, typename Solver, typename Combiner>
+  [[deprecated("Use new interface with predicate argument")]]
   auto divide_conquer(Input && input, 
                       Divider && divide_op, 
                       Solver && solve_op, 

--- a/include/seq/sequential_execution.h
+++ b/include/seq/sequential_execution.h
@@ -170,6 +170,7 @@ public:
   \param combine_op Combiner operation.
   */
   template <typename Input, typename Divider, typename Solver, typename Combiner>
+  [[deprecated("Use new interface with predicate argument")]]
   auto divide_conquer(Input && input, 
                       Divider && divide_op, 
                       Solver && solve_op, 

--- a/include/tbb/parallel_execution_tbb.h
+++ b/include/tbb/parallel_execution_tbb.h
@@ -210,6 +210,7 @@ public:
   \param combine_op Combiner operation.
   */
   template <typename Input, typename Divider, typename Solver, typename Combiner>
+  [[deprecated("Use new interface with predicate argument")]]
   auto divide_conquer(Input && input, 
                       Divider && divide_op, 
                       Solver && solve_op, 


### PR DESCRIPTION
This will be removed probably in v0.4 for now we deprecate.

This solves issue #310 