### PR TITLE
Support only homogeneous reductions

### DIFF
--- a/include/reduce.h
+++ b/include/reduce.h
@@ -59,6 +59,8 @@ auto reduce(const Execution & ex,
 {
   static_assert(supports_reduce<Execution>(),
                 "reduce not supported on execution type");
+  static_assert(std::is_same<Result,typename std::result_of<Combiner(Result,Result)>::type>::value,
+                "reduce combiner should be homogeneous:T = op(T,T)");
   return ex.reduce(first, size,
                    std::forward<Result>(identity), std::forward<Combiner>(combine_op));
 }
@@ -86,6 +88,8 @@ auto reduce(const Execution & ex,
 {
   static_assert(supports_reduce<Execution>(),
       "reduce not supported on execution type");
+  static_assert(std::is_same<Result,typename std::result_of<Combiner(Result,Result)>::type>::value,
+                "reduce combiner should be homogeneous:T = op(T,T)");
   return ex.reduce(first, std::distance(first,last), 
       std::forward<Result>(identity), std::forward<Combiner>(combine_op));
 }

--- a/include/stream_reduce.h
+++ b/include/stream_reduce.h
@@ -50,6 +50,8 @@ auto reduce(int window_size, int offset,
                    Identity identity, 
                    Combiner && combine_op)
 {
+  static_assert(std::is_same<Identity,typename std::result_of<Combiner(Identity,Identity)>::type>::value,
+                "reduce combiner should be homogeneous:T = op(T,T)");
   return reduce_t<Combiner,Identity>(
        window_size, offset, identity, 
        std::forward<Combiner>(combine_op));


### PR DESCRIPTION
Added static asserts to check if combiner operators are homogeneous.