### PR TITLE
Range mapping

### DIFF
--- a/doc/map.md
+++ b/doc/map.md
@@ -50,14 +50,41 @@ U res = op(x1,x2,...,xN)
 An unary **map** takes a data set and transforms each element in the data set by
 applying an unary function and generating a new data set.
 
-The only interface currently offered for this pattern is based in iterators
+There are two interfaces for the unary map:
+
+  * A *range* based interface.
+  * An *iterator* based interface.
+
+#### Range based interface
+
+The *range based* iterface specifies sequences as ranges. A **range** is any type
+satisfying the `grppi::range_concept`. In particular, any STL container is
+a **range**. Thus, sequences provided to `grppi::map` are:
+
+  * The input data set is specified by a range.
+  * The output data set is specified by a range.
+
+---
+**Example**: Doubling values in a vector with ranges.
+~~~{.cpp}
+vector<double> v = get_the_vector();
+vector<double> w(v.size());
+map(exec, v, w,
+    [](double x) { return 2 *x; }
+);
+~~~
+---
+
+#### Iterator based interface
+
+The iterator based interface specifies sequences in terms of iterators
 (following the C++ standard library conventions):
 
   * The input data set is specified by two iterators.
   * The output data set is specified by an iterator to the start of the output sequence.
 
 ---
-**Example**: Doubling values in a vector.
+**Example**: Doubling values in a vector with iterators.
 ~~~{.cpp}
 vector<double> v = get_the_vector();
 vector<double> w(v.size());
@@ -73,15 +100,43 @@ map(exec, begin(v), end(v), begin(w),
 A n-ary **map** takes multiple data sets and transforms a tuple of elements from
 those data sets by applying a n-ary function and generating a new data set.
 
-The only interface currently offered for this pattern is based in iterators:
+There are two interfaces for the n-ary map:
 
-  * The first data set is specified by two iterators.
+  * A *range* based interface.
+  * An *iterator* based interface.
 
+#### Range based n-ary map
+
+The *range based* iterface specifies sequences as ranges. A **range** is any type
+satisfying the `grppi::range_concept`. In particular, any STL container is
+a **range**. Thus, sequences provided to `grppi::map` are:
+
+  * The input data sets are specified by ranges packaged into a `grppi::zip_view` by `grppi::zip`.
+  * The output data set is specified by a range.
+
+---
+**Example**: Computing the addition of three vectors with ranges.
+~~~{.cpp}
+vector<double> v1 = get_first_vector();
+vector<double> v2 = get_second_vector();
+vector<double> v3 = get_third_vector();
+vector<double> w(v1.size());
+map(exec, grppi::zip(v1,v2,v3), w,
+  [](double x, double y, double z) { return x+y+z; },
+);
+~~~
+---
+#### Iterator based n-ary map
+
+The iterator based interface specifies sequences in terms of iterators
+(following the C++ standard library conventions):
+
+  * The input data sets are specified by a tuple of iterators to the start
+    of each sequence
+  * Additionally, the size of those sequences is specified by either an
+    iterator to the end of the first sequence or by an integral value.
   * The output data set is specified by an iterator to the start of the output
     sequence.
-
-  * All the other input data sets are specified by iterators to the start of the
-    input data sequences.
 
 ---
 **Example**: Computing the addition of three vectors.
@@ -90,9 +145,13 @@ vector<double> v1 = get_first_vector();
 vector<double> v2 = get_second_vector();
 vector<double> v3 = get_third_vector();
 vector<double> w(v1.size());
-map(exec, begin(v1), end(v1), begin(w),
+map(exec, std::make_tuple(begin(v1), begin(v2), begin(v3)), end(v1),
+  begin(w),
   [](double x, double y, double z) { return x+y+z; },
-  begin(v2), begin(v3)
+);
+map(exec, std::make_tuple(begin(v1), begin(v2), begin(v3)), v1.size(),
+  begin(w),
+  [](double x, double y, double z) { return x+y+z; },
 );
 ~~~
 ---

--- a/doc/reduce.md
+++ b/doc/reduce.md
@@ -12,12 +12,8 @@ grppi::reduce(exec, other_arguments...);
 
 There is a single variant of the reduction:
 
-* **Sequence reduction without initial value**: Reduces a sequence of values
-with no initial value.
-
-* **Sequence reduction with initial value**: Reduces a sequence of values with
-an initial value.
-
+* **Sequence reduction without identity value**: Reduces a sequence of values
+with an identity value.
 
 ## Key elements in a reduction
 
@@ -50,7 +46,37 @@ Consequently, different associative orders may be used:
 * `cmb(cmb(cmb(cmb(id,x1),x2),cmb(cmb(id,x3),x4)),...)`
 * ...
 
-The only interface currently offered for this pattern is based in iterators
+There are two interfaces for the reduction with identity:
+
+  * A *range* based interface.
+  * An *iterator* based interface.
+
+#### Range based interface
+
+The range based interface specifies sequences as ranges.
+A **range** is any type satisfying the `grppi::range_concept`.
+In particular, any STL sequence container is a **range**.
+Thus, the only sequence provided to `grppi::reduce` is:
+
+  * The input data set is provided by a range:
+
+---
+**Example**: Add the numbers in a sequence.
+~~~{.cpp}
+vector<long> v = get_the_values();
+auto result = reduce(exec,
+  v, 0L,
+  [](long x, long y) { return x+y; }
+);
+~~~
+---
+
+**Note**: Reducing with identity value an empty sequence has a result the
+identity value.
+
+#### Iterator based interface
+
+The iterator based interface specifies sequences in terms of iterators
 (following the C++ standard library conventions):
 
 * The input data set is specified by two iterators.
@@ -60,10 +86,10 @@ The only interface currently offered for this pattern is based in iterators
 ---
 **Example**: Add the lenghts of a sequence of strings.
 ~~~{.cpp}
-vector<string> v = get_the_vector();
+vector<long> v = get_the_values();
 auto result = reduce(exec,
-  begin(v), end(ve), 0
-  [](int n, string s) { return n + s.length(); }
+  begin(v), end(ve), 0L,
+  [](long x, long y) { return x+y; }
 );
 ~~~
 ---

--- a/include/common/meta.h
+++ b/include/common/meta.h
@@ -17,35 +17,67 @@
 #define GRPPI_COMMON_META_H
 
 #if __has_include(<experimental/type_traits>)
-#include <experimental/type_traits>
+#  include <experimental/type_traits>
 #  ifndef __cpp_lib_experimental_detect
 #    error "C++ detection idiom not supported. Upgrade your C++ compiler"
 #  endif
 #else
-#error "Experimental type traits not found. Upgrade your C++ compiler."
+#  error "Experimental type traits not found. Upgrade your C++ compiler."
 #endif
 
 namespace grppi {
 
 namespace meta {
 
-template <template <typename> class E, typename T>
-using is_detected = std::experimental::is_detected<E,T>;
+/**
+\brief Detects if template E<Ts...> is valid.
+\tparam E Expression type.
+\tparam Ts Types used as arguments for E.
+*/
+template <template <typename...> class E, typename ... Ts>
+using is_detected = std::experimental::is_detected<E,Ts...>;
 
-template <typename R, template <typename> class E, typename T>
-using is_detected_convertible = std::experimental::is_detected_convertible<R,E,T>;
+/**
+\brief Detects if template E<Ts...> is valid and convertible to R.
+\tparam R Type to which the expression is convertible.
+\tparam E Expression type.
+\tparam Ts Types used as arguments for E.
+*/
+template <typename R, template <typename...> class E, typename ... Ts>
+using is_detected_convertible = std::experimental::is_detected_convertible<R,E,Ts...>;
 
+
+/**
+\brief Forms the logical conjunction of several traits.
+\tparam Ts Type traits to be conjuncted.
+*/
 template<typename ... Ts> 
 struct conjunction : std::true_type {};
 
+/**
+\brief Specialization of conjunction for a single trait.
+\tparam T Type trait to be conjuncted.
+*/
 template<typename T> 
 struct conjunction<T> : T {};
 
+/**
+\brief Specialization of conjunction for multiple traits.
+\tparam T1 First type trait.
+\tparam Ts Rest of type traits.
+*/
 template<class T1, class... Ts>
 struct conjunction<T1, Ts...> : std::conditional_t<bool(T1::value), conjunction<Ts...>, T1> {};
 
+/**
+\brief Checks if a pack of types all satisfy concept C.
+\tparam C Concept to be checked.
+\tparam Ts Types to be checked against concept.
+If the concept is satisfied has a public typedef type (equal to int), otherwise 
+there is no type defined.
+*/
 template <template <typename> class C, typename ... Ts>
-using requires = std::enable_if_t<meta::conjunction<C<Ts>...>::value,int>;
+using requires = std::enable_if_t<conjunction<C<Ts>...>::value,int>;
 
 }
 

--- a/include/common/meta.h
+++ b/include/common/meta.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Universidad Carlos III de Madrid
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GRPPI_COMMON_META_H
+#define GRPPI_COMMON_META_H
+
+#if __has_include(<experimental/type_traits>)
+#include <experimental/type_traits>
+#  ifndef __cpp_lib_experimental_detect
+#    error "C++ detection idiom not supported. Upgrade your C++ compiler"
+#  endif
+#else
+#error "Experimental type traits not found. Upgrade your C++ compiler."
+#endif
+
+namespace grppi {
+
+namespace meta {
+
+template <template <typename> class E, typename T>
+using is_detected = std::experimental::is_detected<E,T>;
+
+template <typename R, template <typename> class E, typename T>
+using is_detected_convertible = std::experimental::is_detected_convertible<R,E,T>;
+
+template<typename ... Ts> 
+struct conjunction : std::true_type {};
+
+template<typename T> 
+struct conjunction<T> : T {};
+
+template<class T1, class... Ts>
+struct conjunction<T1, Ts...> : std::conditional_t<bool(T1::value), conjunction<Ts...>, T1> {};
+
+template <template <typename> class C, typename ... Ts>
+using requires = std::enable_if_t<meta::conjunction<C<Ts>...>::value,int>;
+
+}
+
+}
+
+#endif

--- a/include/common/range_concept.h
+++ b/include/common/range_concept.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Universidad Carlos III de Madrid
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GRPPI_COMMON_RANGE_CONCEPT_H
+#define GRPPI_COMMON_RANGE_CONCEPT_H
+
+#include "common/meta.h"
+
+namespace grppi {
+
+template <typename T>
+struct range_concept
+{
+  template <typename U>
+  using begin = decltype(std::declval<U>().begin());
+
+  template <typename U>
+  using has_begin = meta::is_detected<begin,U>;
+
+  template <typename U>
+  using end = decltype(std::declval<U>().end());
+
+  template <typename U>
+  using has_end = meta::is_detected<end,U>;
+
+  template <typename U>
+  using size = decltype(std::declval<const U>().size());
+
+  template <typename U>
+  using has_size = meta::is_detected_convertible<std::size_t,size,U>;
+
+  using requires = meta::conjunction<
+      has_begin<T>, 
+      has_end<T>,
+      has_size<T>>;
+
+  static constexpr bool value = requires::value;
+};
+
+template <typename ... Rs, std::size_t ... I>
+std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std::index_sequence<I...>)
+{
+  return std::make_tuple(std::get<I>(rt).begin()...);
+}
+
+template <typename ... Rs,
+        meta::requires<range_concept,Rs...> = 0>
+std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt) 
+{
+  return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
+}
+
+template <typename ... Rs,
+        meta::requires<range_concept,Rs...> = 0>
+auto range_size(std::tuple<Rs...> rt)
+{
+  return std::get<0>(rt).size();
+}
+
+}
+
+#endif

--- a/include/common/range_concept.h
+++ b/include/common/range_concept.h
@@ -50,21 +50,28 @@ struct range_concept
 };
 
 template <typename ... Rs, std::size_t ... I>
-std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std::index_sequence<I...>)
+std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs&...> rt, std::index_sequence<I...>)
 {
   return std::make_tuple(std::get<I>(rt).begin()...);
 }
 
 template <typename ... Rs,
         meta::requires<range_concept,Rs...> = 0>
-std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt) 
+std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs&...> rt) 
 {
   return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
 }
 
 template <typename ... Rs,
         meta::requires<range_concept,Rs...> = 0>
-auto range_size(std::tuple<Rs...> rt)
+std::tuple<typename Rs::iterator...> range_begin(Rs &&... rs) 
+{
+  return range_begin_impl(std::forward_as_tuple(rs...), std::make_index_sequence<sizeof...(Rs)>{});
+}
+
+template <typename ... Rs,
+        meta::requires<range_concept,Rs...> = 0>
+auto range_size(std::tuple<Rs&...> rt)
 {
   return std::get<0>(rt).size();
 }

--- a/include/common/range_concept.h
+++ b/include/common/range_concept.h
@@ -20,61 +20,58 @@
 
 namespace grppi {
 
+/** 
+\addtogroup concepts
+@{
+*/
+
+/**
+\brief Concept for ranges.
+A range is any type that:
+  - Has a begin() member.
+  - Has an end() member.
+  - Has a size() member returning a value convertible to std::size_t.
+*/
 template <typename T>
 struct range_concept
 {
+  /// Return type of U::begin().
   template <typename U>
   using begin = decltype(std::declval<U>().begin());
 
+  /// Detects if a type has begin() member function.
   template <typename U>
   using has_begin = meta::is_detected<begin,U>;
 
+  /// Return type of U::end().
   template <typename U>
   using end = decltype(std::declval<U>().end());
 
+  /// Detects if a type has end() member function.
   template <typename U>
   using has_end = meta::is_detected<end,U>;
 
+  /// Return type of U::size().
   template <typename U>
   using size = decltype(std::declval<const U>().size());
 
+  /// Detects if a type has a size() member function returning std::size_t.
   template <typename U>
   using has_size = meta::is_detected_convertible<std::size_t,size,U>;
 
+  /// Requirements for range_concept.
   using requires = meta::conjunction<
       has_begin<T>, 
       has_end<T>,
       has_size<T>>;
 
+  /// Boolean value for the range_concept requirements.
   static constexpr bool value = requires::value;
 };
 
-template <typename ... Rs, std::size_t ... I>
-std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs&...> rt, std::index_sequence<I...>)
-{
-  return std::make_tuple(std::get<I>(rt).begin()...);
-}
-
-template <typename ... Rs,
-        meta::requires<range_concept,Rs...> = 0>
-std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs&...> rt) 
-{
-  return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
-}
-
-template <typename ... Rs,
-        meta::requires<range_concept,Rs...> = 0>
-std::tuple<typename Rs::iterator...> range_begin(Rs &&... rs) 
-{
-  return range_begin_impl(std::forward_as_tuple(rs...), std::make_index_sequence<sizeof...(Rs)>{});
-}
-
-template <typename ... Rs,
-        meta::requires<range_concept,Rs...> = 0>
-auto range_size(std::tuple<Rs&...> rt)
-{
-  return std::get<0>(rt).size();
-}
+/**
+@}
+*/
 
 }
 

--- a/include/common/zip_view.h
+++ b/include/common/zip_view.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef GRPPI_RANGE_MAPPING_H
-#define GRPPI_RANGE_MAPPING_H
+#ifndef GRPPI_COMMON_ZIP_VIEW_H
+#define GRPPI_COMMON_ZIP_VIEW_H
 
 #include "common/range_concept.h"
 

--- a/include/map.h
+++ b/include/map.h
@@ -47,11 +47,10 @@ namespace grppi {
 */
 template<typename Execution, typename ... InRanges, typename OutRange,
         typename Transformer,
-        requires_ranges<InRanges...> = 0,
-        requires_range<OutRange> = 0>
+        meta::requires<range_concept, InRanges...> = 0,
+        meta::requires<range_concept,OutRange> = 0>
 void map(const Execution & ex, std::tuple<InRanges...> rins, OutRange rout,
-         Transformer transform_op
-        )
+         Transformer transform_op)
 {
   static_assert(supports_map<Execution>(),
       "map not supported on execution type");
@@ -73,8 +72,8 @@ void map(const Execution & ex, std::tuple<InRanges...> rins, OutRange rout,
 */
 template<typename Execution, typename InRange, typename OutRange,
         typename Transformer,
-        requires_range<InRange> = 0,
-        requires_range<OutRange> = 0>
+        meta::requires<range_concept,InRange> = 0,
+        meta::requires<range_concept,OutRange> = 0>
 void map(const Execution & ex, InRange rin, OutRange rout,
          Transformer transform_op)
 {

--- a/include/map.h
+++ b/include/map.h
@@ -36,31 +36,6 @@ namespace grppi {
 /**
 \brief Invoke \ref md_map on a data sequence.
 \tparam Execution Execution policy type.
-\tparam InRanges Range types for the input ranges.
-\tparam OutRange Range type for the output range.
-\tparam Transformer Callable type for the transformation operation.
-\param ex Execution policy object.
-\param rins Input ranges packaged in a std::tuple.
-\param rout Output range.
-\param transform_op Transformation operation.
-\pre for all r in rins: r.size() == rout.size()
-*/
-template<typename Execution, typename ... InRanges, typename OutRange,
-        typename Transformer,
-        meta::requires<range_concept, InRanges...> = 0,
-        meta::requires<range_concept,OutRange> = 0>
-void map(const Execution & ex, zip_view<InRanges...> rins, OutRange && rout,
-         Transformer transform_op)
-{
-  static_assert(supports_map<Execution>(),
-      "map not supported on execution type");
-  ex.map(rins.begin(), rout.begin(),
-         rout.size(), transform_op);
-}
-
-/**
-\brief Invoke \ref md_map on a data sequence.
-\tparam Execution Execution policy type.
 \tparam InRange Range type for the input range.
 \tparam OutRange Range type for the output range.
 \tparam Transformer Callable type for the transformation operation.
@@ -81,6 +56,31 @@ void map(const Execution & ex, InRange && rin, OutRange && rout,
       "map not supported on execution type");
   ex.map(make_tuple(rin.begin()), rout.begin(),
       rin.size(), transform_op);
+}
+
+/**
+\brief Invoke \ref md_map on a data sequence.
+\tparam Execution Execution policy type.
+\tparam InRanges Range types for the input ranges.
+\tparam OutRange Range type for the output range.
+\tparam Transformer Callable type for the transformation operation.
+\param ex Execution policy object.
+\param rins Input ranges packaged in a std::tuple.
+\param rout Output range.
+\param transform_op Transformation operation.
+\pre for all r in rins: r.size() == rout.size()
+*/
+template<typename Execution, typename ... InRanges, typename OutRange,
+        typename Transformer,
+        meta::requires<range_concept, InRanges...> = 0,
+        meta::requires<range_concept,OutRange> = 0>
+void map(const Execution & ex, zip_view<InRanges...> rins, OutRange && rout,
+         Transformer transform_op)
+{
+  static_assert(supports_map<Execution>(),
+      "map not supported on execution type");
+  ex.map(rins.begin(), rout.begin(),
+         rout.size(), transform_op);
 }
 
 /**

--- a/include/map.h
+++ b/include/map.h
@@ -18,6 +18,8 @@
 
 #include <utility>
 
+#include "range_mapping.h"
+
 #include "common/execution_traits.h"
 #include "common/iterator_traits.h"
 
@@ -30,6 +32,57 @@ namespace grppi {
 \brief Interface for applyinng the \ref md_map.
 @{
 */
+
+/**
+\brief Invoke \ref md_map on a data sequence.
+\tparam Execution Execution policy type.
+\tparam InRanges Range types for the input ranges.
+\tparam OutRange Range type for the output range.
+\tparam Transformer Callable type for the transformation operation.
+\param ex Execution policy object.
+\param rins Input ranges packaged in a std::tuple.
+\param rout Output range.
+\param transform_op Transformation operation.
+\pre for all r in rins: r.size() == rout.size()
+*/
+template<typename Execution, typename ... InRanges, typename OutRange,
+        typename Transformer,
+        requires_ranges<InRanges...> = 0,
+        requires_range<OutRange> = 0>
+void map(const Execution & ex, std::tuple<InRanges...> rins, OutRange rout,
+         Transformer transform_op
+        )
+{
+  static_assert(supports_map<Execution>(),
+      "map not supported on execution type");
+  ex.map(range_begin(rins), rout.begin(),
+         rout.size(), transform_op);
+}
+
+/**
+\brief Invoke \ref md_map on a data sequence.
+\tparam Execution Execution policy type.
+\tparam InRange Range type for the input range.
+\tparam OutRange Range type for the output range.
+\tparam Transformer Callable type for the transformation operation.
+\param ex Execution policy object.
+\param rin Input range.
+\param rout Output range.
+\param transform_op Transformation operation.
+\pre rin.size() == rout.size()
+*/
+template<typename Execution, typename InRange, typename OutRange,
+        typename Transformer,
+        requires_range<InRange> = 0,
+        requires_range<OutRange> = 0>
+void map(const Execution & ex, InRange rin, OutRange rout,
+         Transformer transform_op)
+{
+  static_assert(supports_map<Execution>(),
+      "map not supported on execution type");
+  ex.map(make_tuple(rin.begin()), rout.begin(),
+      rin.size(), transform_op);
+}
 
 /**
 \brief Invoke \ref md_map on a data sequence.

--- a/include/map.h
+++ b/include/map.h
@@ -18,8 +18,7 @@
 
 #include <utility>
 
-#include "range_mapping.h"
-
+#include "common/zip_view.h"
 #include "common/execution_traits.h"
 #include "common/iterator_traits.h"
 

--- a/include/map.h
+++ b/include/map.h
@@ -85,59 +85,6 @@ void map(const Execution & ex, zip_view<InRanges...> rins, OutRange && rout,
 
 /**
 \brief Invoke \ref md_map on a data sequence.
-\tparam InputIterators Iterator types used for input sequences.
-\tparam InputIt Iterator type used for any input sequence.
-\tparam OutputIt Iterator type used for the output sequence.
-\tparam Transformer Callable type for the transformation operation.
-\param ex Execution policy object.
-\param firsts Tuple of Iterators to the first element in the inputs sequences.
-\param last Iterator to one past the end of one of the input sequence.
-\param first_out Iterator to first element of the output sequence.
-\param transform_op Transformation operation.
-*/
-template<typename Execution, typename ...InputIterators, typename InputIt,
-        typename OutputIt, typename Transformer,
-        requires_iterators<InputIterators...> = 0,
-        requires_iterator<InputIt> = 0,
-        requires_iterator<OutputIt> = 0>
-void map(const Execution & ex, std::tuple<InputIterators...> firsts,
-         InputIt last, OutputIt first_out,
-         Transformer transform_op)
-{
-  static_assert(supports_map<Execution>(),
-      "map not supported on execution type");
-  ex.map(firsts, first_out,
-      std::distance(std::get<0>(firsts),last), transform_op);
-}
-
-
-
-/**
-\brief Invoke \ref md_map on a data sequence.
-\tparam InputIterators Iterator types used for input sequences.
-\tparam OutputIt Iterator type used for the output sequence.
-\tparam Transformer Callable type for the transformation operation.
-\param ex Execution policy object.
-\param firsts Tuple of Iterators to the first element in the inputs sequences.
-\param range Size of the input sequences to go through.
-\param first_out Iterator to first element of the output sequence.
-\param transform_op Transformation operation.
-*/
-template<typename Execution, typename ...InputIterators,
-        typename OutputIt, typename Transformer,
-        requires_iterators<InputIterators...> = 0,
-        requires_iterator<OutputIt> = 0>
-void map(const Execution & ex, std::tuple<InputIterators...> firsts,
-         std::size_t range, OutputIt first_out,
-         Transformer transformer_op)
-{
-  static_assert(supports_map<Execution>(),
-      "map not supported on execution type");
-  ex.map(firsts, first_out, range, transformer_op);
-}
-
-/**
-\brief Invoke \ref md_map on a data sequence.
 \tparam InputIt Iterator type used for input sequence.
 \tparam OutputIt Iterator type used for the output sequence.
 \tparam Transformer Callable type for the transformation operation.
@@ -163,6 +110,83 @@ void map(const Execution & ex,
 
 /**
 \brief Invoke \ref md_map on a data sequence.
+\tparam InputIterators Iterator types used for input sequences.
+\tparam InputIt Iterator type used for any input sequence.
+\tparam OutputIt Iterator type used for the output sequence.
+\tparam Transformer Callable type for the transformation operation.
+\param ex Execution policy object.
+\param firsts Tuple of Iterators to the first element in the inputs sequences.
+\param last Iterator to one past the end of one of the input sequence.
+\param first_out Iterator to first element of the output sequence.
+\param transform_op Transformation operation.
+*/
+template<typename Execution, typename ...InputIterators, typename InputIt,
+        typename OutputIt, typename Transformer,
+        requires_iterators<InputIterators...> = 0,
+        requires_iterator<InputIt> = 0,
+        requires_iterator<OutputIt> = 0>
+void map(const Execution & ex, std::tuple<InputIterators...> firsts,
+         InputIt last, OutputIt first_out,
+         Transformer transform_op)
+{
+  static_assert(supports_map<Execution>(),
+      "map not supported on execution type");
+  ex.map(firsts, first_out,
+      std::distance(std::get<0>(firsts),last), transform_op);
+}
+
+/**
+\brief Invoke \ref md_map on a data sequence.
+\tparam InputIt Iterator type used for input sequence.
+\tparam OutputIt Iterator type used for the output sequence.
+\tparam Transformer Callable type for the transformation operation.
+\param ex Execution policy object.
+\param first Iterator to the first element in the input sequence.
+\param size Size of the input sequence.
+\param first_out Iterator to first element of the output sequence.
+\param transform_op Transformation operation.
+*/
+template <typename Execution, typename InputIt, typename OutputIt, 
+          typename Transformer,
+          requires_iterator<InputIt> = 0,
+          requires_iterator<OutputIt> = 0>
+void map(const Execution & ex,
+         InputIt first, std::size_t size, OutputIt first_out, 
+         Transformer transform_op) 
+{
+  static_assert(supports_map<Execution>(),
+      "map not supported on execution type");
+  ex.map(make_tuple(first), first_out, size, transform_op);
+}
+
+
+
+/**
+\brief Invoke \ref md_map on a data sequence.
+\tparam InputIterators Iterator types used for input sequences.
+\tparam OutputIt Iterator type used for the output sequence.
+\tparam Transformer Callable type for the transformation operation.
+\param ex Execution policy object.
+\param firsts Tuple of Iterators to the first element in the inputs sequences.
+\param size Size of the input sequences.
+\param first_out Iterator to first element of the output sequence.
+\param transform_op Transformation operation.
+*/
+template<typename Execution, typename ...InputIterators,
+        typename OutputIt, typename Transformer,
+        requires_iterators<InputIterators...> = 0,
+        requires_iterator<OutputIt> = 0>
+void map(const Execution & ex, std::tuple<InputIterators...> firsts,
+         std::size_t size, OutputIt first_out,
+         Transformer transformer_op)
+{
+  static_assert(supports_map<Execution>(),
+      "map not supported on execution type");
+  ex.map(firsts, first_out, size, transformer_op);
+}
+
+/**
+\brief Invoke \ref md_map on a data sequence.
 \tparam InputIt Iterator type used for input sequence.
 \tparam OutputIt Iterator type used for the output sequence.
 \tparam Transformer Callable type for the transformation operation.
@@ -173,13 +197,14 @@ void map(const Execution & ex,
 \param first_out Iterator to first element of the output sequence.
 \param transform_op Transformation operation.
 \param more_firsts Additional iterators with first elements of additional sequences.
+\deprecated For multiple inputs, use tuple or zip versions.
 */
 template <typename Execution, typename InputIt, typename OutputIt, typename Transformer,
           typename ... OtherInputIts,
           requires_iterator<InputIt> = 0,
           requires_iterator<OutputIt> = 0>
 [[deprecated("This version of the interface is deprecated.\n"
-             "If you want to use multiple inputs, use a tuple instead.")]]
+             "For multiple inputs, use a tuple or zip versions.")]]
 void map(const Execution & ex,
          InputIt first, InputIt last, OutputIt first_out, 
          Transformer transform_op, 

--- a/include/map.h
+++ b/include/map.h
@@ -49,12 +49,12 @@ template<typename Execution, typename ... InRanges, typename OutRange,
         typename Transformer,
         meta::requires<range_concept, InRanges...> = 0,
         meta::requires<range_concept,OutRange> = 0>
-void map(const Execution & ex, std::tuple<InRanges...> rins, OutRange rout,
+void map(const Execution & ex, zip_view<InRanges...> rins, OutRange && rout,
          Transformer transform_op)
 {
   static_assert(supports_map<Execution>(),
       "map not supported on execution type");
-  ex.map(range_begin(rins), rout.begin(),
+  ex.map(rins.begin(), rout.begin(),
          rout.size(), transform_op);
 }
 
@@ -74,7 +74,7 @@ template<typename Execution, typename InRange, typename OutRange,
         typename Transformer,
         meta::requires<range_concept,InRange> = 0,
         meta::requires<range_concept,OutRange> = 0>
-void map(const Execution & ex, InRange rin, OutRange rout,
+void map(const Execution & ex, InRange && rin, OutRange && rout,
          Transformer transform_op)
 {
   static_assert(supports_map<Execution>(),

--- a/include/mapreduce.h
+++ b/include/mapreduce.h
@@ -18,6 +18,7 @@
 
 #include <utility>
 
+#include "range_mapping.h"
 #include "common/execution_traits.h"
 #include "common/iterator_traits.h"
 
@@ -30,6 +31,69 @@ namespace grppi {
 \brief Interface for applyinng the \ref md_map-reduce.
 @{
 */
+
+/**
+\brief Invoke \ref md_map-reduce on a data sequence.
+\tparam Execution Execution type.
+\tparam InputIterator Iterator type used for the input sequence.
+\tparam Identity Type for the identity value.
+\tparam Transformer Callable type for the transformation operation.
+\tparam Combiner Callable type for the combination operation of the reduction.
+\param ex Execution policy object.
+\param first Iterator to the first element in the input sequence.
+\param last Iterator to one past the end of the input sequence.
+\param identity Identity value for the combination operation.
+\param transf_op Transformation operation.
+\param combine_op Combination operation.
+\return Result of the map/reduce operation.
+*/
+template <typename Execution, typename InputRange, typename Identity, 
+          typename Transformer, typename Combiner,
+          requires_range<InputRange> = 0>
+auto map_reduce(const Execution & ex, 
+                InputRange rin,
+                Identity && identity, 
+                Transformer &&  transform_op, Combiner && combine_op)
+{
+  static_assert(supports_map_reduce<Execution>(),
+    "map/reduce not supported on execution type");
+  return ex.map_reduce(std::make_tuple(rin.begin()), rin.size(),
+      std::forward<Identity>(identity),
+      std::forward<Transformer>(transform_op), 
+      std::forward<Combiner>(combine_op));
+}
+
+/**
+\brief Invoke \ref md_map-reduce on a data sequence.
+\tparam Execution Execution type.
+\tparam InputIterators Iterators types used for the input sequences.
+\tparam Identity Type for the identity value.
+\tparam Transformer Callable type for the transformation operation.
+\tparam Combiner Callable type for the combination operation of the reduction.
+\param ex Execution policy object.
+\param firsts Tuple of iterators to the first elements in the input sequences.
+\param size Size of the input sequence to be process.
+\param identity Identity value for the combination operation.
+\param transf_op Transformation operation.
+\param combine_op Combination operation.
+\return Result of the map/reduce operation.
+*/
+template <typename Execution, 
+    typename ... InputRanges,
+    typename Identity, typename Transformer, typename Combiner,
+    requires_ranges<InputRanges ...> = 0>
+auto map_reduce(const Execution & ex,
+                std::tuple<InputRanges...> rins,
+                Identity && identity,
+                Transformer &&  transform_op, Combiner && combine_op)
+{
+  static_assert(supports_map_reduce<Execution>(),
+                "map/reduce not supported on execution type");
+  return ex.map_reduce(range_begin(rins), range_size(rins),
+                       std::forward<Identity>(identity),
+                       std::forward<Transformer>(transform_op),
+                       std::forward<Combiner>(combine_op));
+}
 
 /**
 \brief Invoke \ref md_map-reduce on a data sequence.
@@ -121,7 +185,7 @@ auto map_reduce(const Execution & ex,
 {
   static_assert(supports_map_reduce<Execution>(),
     "map/reduce not supported on execution type");
-  return ex.map_reduce(make_tuple(first), std::distance(first,last), 
+  return ex.map_reduce(std::make_tuple(first), std::distance(first,last), 
       std::forward<Identity>(identity),
       std::forward<Transformer>(transform_op), 
       std::forward<Combiner>(combine_op));
@@ -156,7 +220,7 @@ auto map_reduce(const Execution & ex,
 {
   static_assert(supports_map_reduce<Execution>(),
     "map/reduce not supported on execution type");
-  return ex.map_reduce(make_tuple(first, other_firsts...), 
+  return ex.map_reduce(std::make_tuple(first, other_firsts...), 
       std::distance(first,last), 
       std::forward<Identity>(identity),
       std::forward<Transformer>(transform_op), 

--- a/include/mapreduce.h
+++ b/include/mapreduce.h
@@ -18,7 +18,7 @@
 
 #include <utility>
 
-#include "range_mapping.h"
+#include "common/zip_view.h"
 #include "common/execution_traits.h"
 #include "common/iterator_traits.h"
 

--- a/include/mapreduce.h
+++ b/include/mapreduce.h
@@ -96,32 +96,32 @@ auto map_reduce(const Execution & ex,
 /**
 \brief Invoke \ref md_map-reduce on a data sequence.
 \tparam Execution Execution type.
-\tparam InputIterators Iterators types used for the input sequences.
+\tparam InputIterator Iterator type used for the input sequence.
 \tparam Identity Type for the identity value.
 \tparam Transformer Callable type for the transformation operation.
 \tparam Combiner Callable type for the combination operation of the reduction.
 \param ex Execution policy object.
-\param firsts Tuple of iterators to the first elements in the input sequences.
-\param size Size of the input sequence to be process.
+\param first Iterator to the first element in the input sequence.
+\param last Iterator to one past the end of the input sequence.
 \param identity Identity value for the combination operation.
 \param transf_op Transformation operation.
 \param combine_op Combination operation.
 \return Result of the map/reduce operation.
 */
-template <typename Execution, typename ...InputIterators,
-    typename Identity, typename Transformer, typename Combiner,
-    requires_iterators<InputIterators...> = 0>
-auto map_reduce(const Execution & ex,
-                std::tuple<InputIterators...> firsts, std::size_t size,
-                Identity && identity,
+template <typename Execution, typename InputIterator, typename Identity, 
+          typename Transformer, typename Combiner,
+          requires_iterator<InputIterator> = 0>
+auto map_reduce(const Execution & ex, 
+                InputIterator first, InputIterator last, 
+                Identity && identity, 
                 Transformer &&  transform_op, Combiner && combine_op)
 {
   static_assert(supports_map_reduce<Execution>(),
-                "map/reduce not supported on execution type");
-  return ex.map_reduce(firsts, size,
-                       std::forward<Identity>(identity),
-                       std::forward<Transformer>(transform_op),
-                       std::forward<Combiner>(combine_op));
+    "map/reduce not supported on execution type");
+  return ex.map_reduce(std::make_tuple(first), std::distance(first,last), 
+      std::forward<Identity>(identity),
+      std::forward<Transformer>(transform_op), 
+      std::forward<Combiner>(combine_op));
 }
 
 /**
@@ -167,7 +167,7 @@ auto map_reduce(const Execution & ex,
 \tparam Combiner Callable type for the combination operation of the reduction.
 \param ex Execution policy object.
 \param first Iterator to the first element in the input sequence.
-\param last Iterator to one past the end of the input sequence.
+\param size Size of the input sequence to be processed.
 \param identity Identity value for the combination operation.
 \param transf_op Transformation operation.
 \param combine_op Combination operation.
@@ -177,16 +177,47 @@ template <typename Execution, typename InputIterator, typename Identity,
           typename Transformer, typename Combiner,
           requires_iterator<InputIterator> = 0>
 auto map_reduce(const Execution & ex, 
-                InputIterator first, InputIterator last, 
+                InputIterator first, std::size_t size,
                 Identity && identity, 
                 Transformer &&  transform_op, Combiner && combine_op)
 {
   static_assert(supports_map_reduce<Execution>(),
     "map/reduce not supported on execution type");
-  return ex.map_reduce(std::make_tuple(first), std::distance(first,last), 
+  return ex.map_reduce(std::make_tuple(first), size,
       std::forward<Identity>(identity),
       std::forward<Transformer>(transform_op), 
       std::forward<Combiner>(combine_op));
+}
+
+/**
+\brief Invoke \ref md_map-reduce on a data sequence.
+\tparam Execution Execution type.
+\tparam InputIterators Iterators types used for the input sequences.
+\tparam Identity Type for the identity value.
+\tparam Transformer Callable type for the transformation operation.
+\tparam Combiner Callable type for the combination operation of the reduction.
+\param ex Execution policy object.
+\param firsts Tuple of iterators to the first elements in the input sequences.
+\param size Size of the input sequence to be processed.
+\param identity Identity value for the combination operation.
+\param transf_op Transformation operation.
+\param combine_op Combination operation.
+\return Result of the map/reduce operation.
+*/
+template <typename Execution, typename ...InputIterators,
+    typename Identity, typename Transformer, typename Combiner,
+    requires_iterators<InputIterators...> = 0>
+auto map_reduce(const Execution & ex,
+                std::tuple<InputIterators...> firsts, std::size_t size,
+                Identity && identity,
+                Transformer &&  transform_op, Combiner && combine_op)
+{
+  static_assert(supports_map_reduce<Execution>(),
+                "map/reduce not supported on execution type");
+  return ex.map_reduce(firsts, size,
+                       std::forward<Identity>(identity),
+                       std::forward<Transformer>(transform_op),
+                       std::forward<Combiner>(combine_op));
 }
 
 /**
@@ -203,13 +234,14 @@ auto map_reduce(const Execution & ex,
 \param transf_op Transformation operation.
 \param combine_op Combination operation.
 \return Result of the map/reduce operation.
+\deprecated For multiple inputs, use tuple or zip versions.
 */
 template <typename Execution, typename InputIterator, typename Identity, 
           typename Transformer, typename Combiner,
           typename ... OtherInputIterators,
           requires_iterator<InputIterator> = 0>
 [[deprecated("This version of the interface is deprecated.\n"
-             "If you want to use multiple inputs, use a tuple instead.")]]
+             "For multiple inputs, use a tuple or zip versions.")]]
 auto map_reduce(const Execution & ex,
                 InputIterator first, InputIterator last, 
                 Identity && identity, 

--- a/include/mapreduce.h
+++ b/include/mapreduce.h
@@ -51,7 +51,7 @@ template <typename Execution, typename InputRange, typename Identity,
           typename Transformer, typename Combiner,
           meta::requires<range_concept,InputRange> = 0>
 auto map_reduce(const Execution & ex, 
-                InputRange rin,
+                InputRange && rin,
                 Identity && identity, 
                 Transformer &&  transform_op, Combiner && combine_op)
 {
@@ -83,13 +83,13 @@ template <typename Execution,
     typename Identity, typename Transformer, typename Combiner,
     meta::requires<range_concept,InputRanges ...> = 0>
 auto map_reduce(const Execution & ex,
-                std::tuple<InputRanges...> rins,
+                zip_view<InputRanges...> rins,
                 Identity && identity,
                 Transformer &&  transform_op, Combiner && combine_op)
 {
   static_assert(supports_map_reduce<Execution>(),
                 "map/reduce not supported on execution type");
-  return ex.map_reduce(range_begin(rins), range_size(rins),
+  return ex.map_reduce(rins.begin(), rins.size(),
                        std::forward<Identity>(identity),
                        std::forward<Transformer>(transform_op),
                        std::forward<Combiner>(combine_op));

--- a/include/mapreduce.h
+++ b/include/mapreduce.h
@@ -35,13 +35,12 @@ namespace grppi {
 /**
 \brief Invoke \ref md_map-reduce on a data sequence.
 \tparam Execution Execution type.
-\tparam InputIterator Iterator type used for the input sequence.
+\tparam InputRange Range type used for the input sequence.
 \tparam Identity Type for the identity value.
 \tparam Transformer Callable type for the transformation operation.
 \tparam Combiner Callable type for the combination operation of the reduction.
 \param ex Execution policy object.
-\param first Iterator to the first element in the input sequence.
-\param last Iterator to one past the end of the input sequence.
+\param rin Range for the input sequence.
 \param identity Identity value for the combination operation.
 \param transf_op Transformation operation.
 \param combine_op Combination operation.
@@ -66,13 +65,12 @@ auto map_reduce(const Execution & ex,
 /**
 \brief Invoke \ref md_map-reduce on a data sequence.
 \tparam Execution Execution type.
-\tparam InputIterators Iterators types used for the input sequences.
+\tparam InputRanges Range types used for the input sequences.
 \tparam Identity Type for the identity value.
 \tparam Transformer Callable type for the transformation operation.
 \tparam Combiner Callable type for the combination operation of the reduction.
 \param ex Execution policy object.
-\param firsts Tuple of iterators to the first elements in the input sequences.
-\param size Size of the input sequence to be process.
+\param rins Zip view for the input sequences.
 \param identity Identity value for the combination operation.
 \param transf_op Transformation operation.
 \param combine_op Combination operation.

--- a/include/mapreduce.h
+++ b/include/mapreduce.h
@@ -49,7 +49,7 @@ namespace grppi {
 */
 template <typename Execution, typename InputRange, typename Identity, 
           typename Transformer, typename Combiner,
-          requires_range<InputRange> = 0>
+          meta::requires<range_concept,InputRange> = 0>
 auto map_reduce(const Execution & ex, 
                 InputRange rin,
                 Identity && identity, 
@@ -81,7 +81,7 @@ auto map_reduce(const Execution & ex,
 template <typename Execution, 
     typename ... InputRanges,
     typename Identity, typename Transformer, typename Combiner,
-    requires_ranges<InputRanges ...> = 0>
+    meta::requires<range_concept,InputRanges ...> = 0>
 auto map_reduce(const Execution & ex,
                 std::tuple<InputRanges...> rins,
                 Identity && identity,

--- a/include/range_mapping.h
+++ b/include/range_mapping.h
@@ -16,6 +16,8 @@
 #ifndef GRPPI_RANGE_MAPPING_H
 #define GRPPI_RANGE_MAPPING_H
 
+#include <experimental/type_traits>
+
 namespace grppi {
 
 template <typename C>
@@ -34,51 +36,79 @@ private:
   iterator first_, last_;
 };
 
-template <typename C>
+namespace meta {
+
+template <typename T, template <typename> class E>
+using has_member = std::experimental::is_detected<E,T>;
+
+template <typename T, typename R, template <typename> class E>
+using has_member_returning = std::experimental::is_detected_convertible<R,E,T>;
+
+template<typename ... Ts> 
+struct conjunction : std::true_type {};
+
+template<typename T> 
+struct conjunction<T> : T {};
+
+template<class T1, class... Ts>
+struct conjunction<T1, Ts...> : std::conditional_t<bool(T1::value), conjunction<Ts...>, T1> {};
+
+template <template <typename> class C, typename ... Ts>
+using requires = std::enable_if_t<meta::conjunction<C<Ts>...>::value,int>;
+
+}
+
+template <typename T>
+struct range_concept
+{
+  template <typename U>
+  using begin = decltype(std::declval<U>().begin());
+
+  template <typename U>
+  using has_begin = meta::has_member<U,begin>;
+
+  template <typename U>
+  using end = decltype(std::declval<U>().end());
+
+  template <typename U>
+  using has_end = meta::has_member<U,end>;
+
+  template <typename U>
+  using size = decltype(std::declval<const U>().size());
+
+  template <typename U>
+  using has_size = meta::has_member_returning<U,std::size_t,size>;
+
+  using requires = meta::conjunction<
+      has_begin<T>, 
+      has_end<T>,
+      has_size<T>>;
+
+  static constexpr bool value = requires::value;
+};
+
+template <typename T>
+using requires_range = meta::requires<range_concept,T>;
+
+template <typename ... Ts>
+using requires_ranges = meta::requires<range_concept,Ts...>;
+
+template <typename C,
+        requires_range<C> = 0>
 range_mapping<C> make_range(C & c) { return {c}; }
 
-template <typename ... Cs>
+template <typename ... Cs,
+        requires_ranges<Cs...> = 0>
 std::tuple<range_mapping<Cs>...> make_ranges(Cs & ... c) 
-{ 
+{
   return std::make_tuple(range_mapping<Cs>{c}...); 
 }
 
-
 template <typename R>
-struct is_range_impl
-{
-  static constexpr bool value = false;
-};
-
-template <typename C>
-struct is_range_impl<range_mapping<C>> {
-  static constexpr bool value = true;
-};
-
-template <typename R, typename ... Rs>
-struct are_ranges_impl
-{
-  static constexpr bool value = is_range_impl<R>::value && are_ranges_impl<Rs...>::value;
-};
-
-template <typename R>
-struct are_ranges_impl<R>
-{
-  static constexpr bool value = is_range_impl<R>::value;
-};
-
-
-template <typename R>
-constexpr bool is_range() { return is_range_impl<R>::value; }
+constexpr bool is_range() { return range_concept<R>::requires::value; }
 
 template <typename ... Rs>
-constexpr bool are_ranges() { return are_ranges_impl<Rs...>::value; } 
-
-template <typename R>
-using requires_range = std::enable_if_t<is_range<R>(), int>;
-
-template <typename ... Rs>
-using requires_ranges = std::enable_if_t<are_ranges<Rs...>(), int>;
+constexpr bool are_ranges() { return meta::conjunction<range_concept<Rs>...>::value; } 
 
 template <typename ... Rs, std::size_t ... I>
 std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std::index_sequence<I...>)
@@ -86,13 +116,15 @@ std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std:
   return std::make_tuple(std::get<I>(rt).begin()...);
 }
 
-template <typename ... Rs>
+template <typename ... Rs,
+        requires_ranges<Rs...> = 0>
 std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt) 
 {
   return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
 }
 
-template <typename ... Rs>
+template <typename ... Rs,
+        requires_ranges<Rs...> = 0>
 auto range_size(std::tuple<Rs...> rt)
 {
   return std::get<0>(rt).size();

--- a/include/range_mapping.h
+++ b/include/range_mapping.h
@@ -47,6 +47,31 @@ std::tuple<range_mapping<Cs>...> make_ranges(Cs & ... c)
   return std::make_tuple(range_mapping<Cs>{c}...); 
 }
 
+template <typename ... Rs>
+class zip_view {
+public:
+  zip_view(Rs& ... rs) : rngs_{rs...} {}
+
+  auto begin() { return begin_impl(std::make_index_sequence<sizeof...(Rs)>{}); }
+
+  auto size() {
+    return std::get<0>(rngs_).size();
+  }
+
+private:
+  std::tuple<Rs&...> rngs_;
+
+private:
+
+  template <std::size_t ... I>
+  auto begin_impl(std::index_sequence<I...>) {
+    return std::make_tuple(std::get<I>(rngs_).begin()...);
+  }
+};
+
+template <typename ... Rs>
+auto zip(Rs & ... rs) { return zip_view<Rs...>(rs...); }
+
 }
 
 #endif

--- a/include/range_mapping.h
+++ b/include/range_mapping.h
@@ -92,6 +92,12 @@ std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt)
   return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
 }
 
+template <typename ... Rs>
+auto range_size(std::tuple<Rs...> rt)
+{
+  return std::get<0>(rt).size();
+}
+
 
 }
 

--- a/include/range_mapping.h
+++ b/include/range_mapping.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Universidad Carlos III de Madrid
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GRPPI_RANGE_MAPPING_H
+#define GRPPI_RANGE_MAPPING_H
+
+namespace grppi {
+
+template <typename C>
+class range_mapping {
+public:
+  using iterator = typename C::iterator;
+
+  range_mapping(C & c) : first_{c.begin()}, last_{c.end()} {}
+  range_mapping(iterator f, iterator l) : first_{f}, last_{l} {}
+
+  auto begin() { return first_; }
+  auto end() { return last_; }
+  auto size() const { return std::distance(first_,last_); }
+
+private:
+  iterator first_, last_;
+};
+
+template <typename C>
+range_mapping<C> make_range(C & c) { return {c}; }
+
+template <typename ... Cs>
+std::tuple<range_mapping<Cs>...> make_ranges(Cs & ... c) 
+{ 
+  return std::make_tuple(range_mapping<Cs>{c}...); 
+}
+
+
+template <typename R>
+struct is_range_impl
+{
+  static constexpr bool value = false;
+};
+
+template <typename C>
+struct is_range_impl<range_mapping<C>> {
+  static constexpr bool value = true;
+};
+
+template <typename R, typename ... Rs>
+struct are_ranges_impl
+{
+  static constexpr bool value = is_range_impl<R>::value && are_ranges_impl<Rs...>::value;
+};
+
+template <typename R>
+struct are_ranges_impl<R>
+{
+  static constexpr bool value = is_range_impl<R>::value;
+};
+
+
+template <typename R>
+constexpr bool is_range() { return is_range_impl<R>::value; }
+
+template <typename ... Rs>
+constexpr bool are_ranges() { return are_ranges_impl<Rs...>::value; } 
+
+template <typename R>
+using requires_range = std::enable_if_t<is_range<R>(), int>;
+
+template <typename ... Rs>
+using requires_ranges = std::enable_if_t<are_ranges<Rs...>(), int>;
+
+template <typename ... Rs, std::size_t ... I>
+std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std::index_sequence<I...>)
+{
+  return std::make_tuple(std::get<I>(rt).begin()...);
+}
+
+template <typename ... Rs>
+std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt) 
+{
+  return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
+}
+
+
+}
+
+#endif

--- a/include/range_mapping.h
+++ b/include/range_mapping.h
@@ -16,58 +16,9 @@
 #ifndef GRPPI_RANGE_MAPPING_H
 #define GRPPI_RANGE_MAPPING_H
 
-#include "common/meta.h"
+#include "common/range_concept.h"
 
 namespace grppi {
-
-template <typename T>
-struct range_concept
-{
-  template <typename U>
-  using begin = decltype(std::declval<U>().begin());
-
-  template <typename U>
-  using has_begin = meta::is_detected<begin,U>;
-
-  template <typename U>
-  using end = decltype(std::declval<U>().end());
-
-  template <typename U>
-  using has_end = meta::is_detected<end,U>;
-
-  template <typename U>
-  using size = decltype(std::declval<const U>().size());
-
-  template <typename U>
-  using has_size = meta::is_detected_convertible<std::size_t,size,U>;
-
-  using requires = meta::conjunction<
-      has_begin<T>, 
-      has_end<T>,
-      has_size<T>>;
-
-  static constexpr bool value = requires::value;
-};
-
-template <typename ... Rs, std::size_t ... I>
-std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std::index_sequence<I...>)
-{
-  return std::make_tuple(std::get<I>(rt).begin()...);
-}
-
-template <typename ... Rs,
-        meta::requires<range_concept,Rs...> = 0>
-std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt) 
-{
-  return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
-}
-
-template <typename ... Rs,
-        meta::requires<range_concept,Rs...> = 0>
-auto range_size(std::tuple<Rs...> rt)
-{
-  return std::get<0>(rt).size();
-}
 
 template <typename C>
 class range_mapping {

--- a/include/range_mapping.h
+++ b/include/range_mapping.h
@@ -16,9 +16,58 @@
 #ifndef GRPPI_RANGE_MAPPING_H
 #define GRPPI_RANGE_MAPPING_H
 
-#include <experimental/type_traits>
+#include "common/meta.h"
 
 namespace grppi {
+
+template <typename T>
+struct range_concept
+{
+  template <typename U>
+  using begin = decltype(std::declval<U>().begin());
+
+  template <typename U>
+  using has_begin = meta::is_detected<begin,U>;
+
+  template <typename U>
+  using end = decltype(std::declval<U>().end());
+
+  template <typename U>
+  using has_end = meta::is_detected<end,U>;
+
+  template <typename U>
+  using size = decltype(std::declval<const U>().size());
+
+  template <typename U>
+  using has_size = meta::is_detected_convertible<std::size_t,size,U>;
+
+  using requires = meta::conjunction<
+      has_begin<T>, 
+      has_end<T>,
+      has_size<T>>;
+
+  static constexpr bool value = requires::value;
+};
+
+template <typename ... Rs, std::size_t ... I>
+std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std::index_sequence<I...>)
+{
+  return std::make_tuple(std::get<I>(rt).begin()...);
+}
+
+template <typename ... Rs,
+        meta::requires<range_concept,Rs...> = 0>
+std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt) 
+{
+  return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
+}
+
+template <typename ... Rs,
+        meta::requires<range_concept,Rs...> = 0>
+auto range_size(std::tuple<Rs...> rt)
+{
+  return std::get<0>(rt).size();
+}
 
 template <typename C>
 class range_mapping {
@@ -36,100 +85,16 @@ private:
   iterator first_, last_;
 };
 
-namespace meta {
-
-template <typename T, template <typename> class E>
-using has_member = std::experimental::is_detected<E,T>;
-
-template <typename T, typename R, template <typename> class E>
-using has_member_returning = std::experimental::is_detected_convertible<R,E,T>;
-
-template<typename ... Ts> 
-struct conjunction : std::true_type {};
-
-template<typename T> 
-struct conjunction<T> : T {};
-
-template<class T1, class... Ts>
-struct conjunction<T1, Ts...> : std::conditional_t<bool(T1::value), conjunction<Ts...>, T1> {};
-
-template <template <typename> class C, typename ... Ts>
-using requires = std::enable_if_t<meta::conjunction<C<Ts>...>::value,int>;
-
-}
-
-template <typename T>
-struct range_concept
-{
-  template <typename U>
-  using begin = decltype(std::declval<U>().begin());
-
-  template <typename U>
-  using has_begin = meta::has_member<U,begin>;
-
-  template <typename U>
-  using end = decltype(std::declval<U>().end());
-
-  template <typename U>
-  using has_end = meta::has_member<U,end>;
-
-  template <typename U>
-  using size = decltype(std::declval<const U>().size());
-
-  template <typename U>
-  using has_size = meta::has_member_returning<U,std::size_t,size>;
-
-  using requires = meta::conjunction<
-      has_begin<T>, 
-      has_end<T>,
-      has_size<T>>;
-
-  static constexpr bool value = requires::value;
-};
-
-template <typename T>
-using requires_range = meta::requires<range_concept,T>;
-
-template <typename ... Ts>
-using requires_ranges = meta::requires<range_concept,Ts...>;
-
 template <typename C,
-        requires_range<C> = 0>
+        meta::requires<range_concept,C> = 0>
 range_mapping<C> make_range(C & c) { return {c}; }
 
 template <typename ... Cs,
-        requires_ranges<Cs...> = 0>
+        meta::requires<range_concept,Cs...> = 0>
 std::tuple<range_mapping<Cs>...> make_ranges(Cs & ... c) 
 {
   return std::make_tuple(range_mapping<Cs>{c}...); 
 }
-
-template <typename R>
-constexpr bool is_range() { return range_concept<R>::requires::value; }
-
-template <typename ... Rs>
-constexpr bool are_ranges() { return meta::conjunction<range_concept<Rs>...>::value; } 
-
-template <typename ... Rs, std::size_t ... I>
-std::tuple<typename Rs::iterator...> range_begin_impl(std::tuple<Rs...> rt, std::index_sequence<I...>)
-{
-  return std::make_tuple(std::get<I>(rt).begin()...);
-}
-
-template <typename ... Rs,
-        requires_ranges<Rs...> = 0>
-std::tuple<typename Rs::iterator...> range_begin(std::tuple<Rs...> rt) 
-{
-  return range_begin_impl(rt, std::make_index_sequence<sizeof...(Rs)>{});
-}
-
-template <typename ... Rs,
-        requires_ranges<Rs...> = 0>
-auto range_size(std::tuple<Rs...> rt)
-{
-  return std::get<0>(rt).size();
-}
-
 
 }
 

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -70,35 +70,6 @@ on a data sequence with sequential execution.
 \tparam Combiner Callable type for the combiner operation.
 \param ex Execution policy object.
 \param first Iterator to the first element in the input sequence.
-\param size Size of the input sequence to be process.
-\param identity Identity value for the combiner operation.
-\param combiner_op Combiner operation for the reduction.
-\return The result of the reduction.
-*/
-template <typename Execution, typename InputIt, typename Result, typename Combiner,
-    requires_iterator<InputIt> = 0>
-auto reduce(const Execution & ex,
-            InputIt first, std::size_t size,
-            Result && identity,
-            Combiner && combine_op)
-{
-  static_assert(supports_reduce<Execution>(),
-                "reduce not supported on execution type");
-//  static_assert(std::is_same<Result,typename std::result_of<Combiner(Result,Result)>::type>::value,
-//                "reduce combiner should be homogeneous:T = op(T,T)");
-  return ex.reduce(first, size,
-                   std::forward<Result>(identity), std::forward<Combiner>(combine_op));
-}
-
-/**
-\brief Invoke \ref md_reduce with identity value
-on a data sequence with sequential execution.
-\tparam Execution Execution type.
-\tparam InputIt Iterator type used for input sequence.
-\tparam Result Type for the identity value.
-\tparam Combiner Callable type for the combiner operation.
-\param ex Execution policy object.
-\param first Iterator to the first element in the input sequence.
 \param last Iterator to one past the end of the input sequence.
 \param identity Identity value for the combiner operation.
 \param combiner_op Combiner operation for the reduction.
@@ -117,6 +88,35 @@ auto reduce(const Execution & ex,
 //                "reduce combiner should be homogeneous:T = op(T,T)");
   return ex.reduce(first, std::distance(first,last), 
       std::forward<Result>(identity), std::forward<Combiner>(combine_op));
+}
+
+/**
+\brief Invoke \ref md_reduce with identity value
+on a data sequence with sequential execution.
+\tparam Execution Execution type.
+\tparam InputIt Iterator type used for input sequence.
+\tparam Result Type for the identity value.
+\tparam Combiner Callable type for the combiner operation.
+\param ex Execution policy object.
+\param first Iterator to the first element in the input sequence.
+\param size Size of the input sequence to be process.
+\param identity Identity value for the combiner operation.
+\param combiner_op Combiner operation for the reduction.
+\return The result of the reduction.
+*/
+template <typename Execution, typename InputIt, typename Result, typename Combiner,
+    requires_iterator<InputIt> = 0>
+auto reduce(const Execution & ex,
+            InputIt first, std::size_t size,
+            Result && identity,
+            Combiner && combine_op)
+{
+  static_assert(supports_reduce<Execution>(),
+                "reduce not supported on execution type");
+//  static_assert(std::is_same<Result,typename std::result_of<Combiner(Result,Result)>::type>::value,
+//                "reduce combiner should be homogeneous:T = op(T,T)");
+  return ex.reduce(first, size,
+                   std::forward<Result>(identity), std::forward<Combiner>(combine_op));
 }
 
 /**

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -48,7 +48,7 @@ on a data sequence with sequential execution.
 template <typename Execution, typename InRange, typename Result, typename Combiner,
     meta::requires<range_concept,InRange> = 0>
 auto reduce(const Execution & ex,
-            InRange rin,
+            InRange && rin,
             Result && identity,
             Combiner && combine_op)
 {

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -18,6 +18,7 @@
 
 #include <utility>
 
+#include "range_mapping.h"
 #include "common/iterator_traits.h"
 #include "common/execution_traits.h"
 
@@ -30,6 +31,35 @@ namespace grppi {
 \brief Interface for applyinng the \ref md_reduce.
 @{
 */
+
+/**
+\brief Invoke \ref md_reduce with identity value
+on a data sequence with sequential execution.
+\tparam Execution Execution type.
+\tparam InRange Range type for the input range.
+\tparam Result Type for the identity value.
+\tparam Combiner Callable type for the combiner operation.
+\param ex Execution policy object.
+\param rin Input range.
+\param identity Identity value for the combiner operation.
+\param combiner_op Combiner operation for the reduction.
+\return The result of the reduction.
+*/
+template <typename Execution, typename InRange, typename Result, typename Combiner,
+    requires_range<InRange> = 0>
+auto reduce(const Execution & ex,
+            InRange rin,
+            Result && identity,
+            Combiner && combine_op)
+{
+  static_assert(supports_reduce<Execution>(),
+                "reduce not supported on execution type");
+//  static_assert(std::is_same<Result,typename std::result_of<Combiner(Result,Result)>::type>::value,
+//                "reduce combiner should be homogeneous:T = op(T,T)");
+  return ex.reduce(rin.begin(), rin.size(),
+                   std::forward<Result>(identity), std::forward<Combiner>(combine_op));
+}
+
 
 /**
 \brief Invoke \ref md_reduce with identity value

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -18,7 +18,7 @@
 
 #include <utility>
 
-#include "range_mapping.h"
+#include "common/range_concept.h"
 #include "common/iterator_traits.h"
 #include "common/execution_traits.h"
 

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -46,7 +46,7 @@ on a data sequence with sequential execution.
 \return The result of the reduction.
 */
 template <typename Execution, typename InRange, typename Result, typename Combiner,
-    requires_range<InRange> = 0>
+    meta::requires<range_concept,InRange> = 0>
 auto reduce(const Execution & ex,
             InRange rin,
             Result && identity,

--- a/include/stencil.h
+++ b/include/stencil.h
@@ -54,7 +54,7 @@ template <typename Execution, typename InputRange, typename OutputRange,
           meta::requires<range_concept,OutputRange> = 0>
 void stencil(
     const Execution & ex, 
-    InputRange rin, OutputRange rout,
+    InputRange && rin, OutputRange && rout,
     StencilTransformer && transform_op, 
     Neighbourhood && neighbour_op) 
 {
@@ -87,13 +87,13 @@ template <typename Execution, typename ... InputRanges, typename OutputRange,
           meta::requires<range_concept,OutputRange> = 0>
 void stencil(
     const Execution & ex,
-    std::tuple<InputRanges...> rins, OutputRange rout,
+    zip_view<InputRanges...> rins, OutputRange && rout,
     StencilTransformer && transform_op,
     Neighbourhood && neighbour_op)
 {
   static_assert(supports_stencil<Execution>(),
                 "stencil not supported for execution type");
-  ex.stencil(range_begin(rins), rout.begin(), range_size(rins),
+  ex.stencil(rins.begin(), rout.begin(), rins.size(),
              std::forward<StencilTransformer>(transform_op),
              std::forward<Neighbourhood>(neighbour_op));
 }

--- a/include/stencil.h
+++ b/include/stencil.h
@@ -97,35 +97,36 @@ void stencil(
 }
 
 /**
-\brief Invoke \ref md_stencil on a data sequence with
+\brief Invoke \ref md_stencil on a data sequence with 
 sequential execution.
 \tparam Execution Execution type.
-\tparam InputIterators Iterators types used for the input sequences.
+\tparam InputIt Iterator type used for the input sequence.
 \tparam OutputIt Iterator type used for the output sequence
-\tparam StencilTransformer Callable type for performing the stencil transformation.
 \tparam Neighbourhood Callable type for obtaining the neighbourhood.
+\tparam StencilTransformer Callable type for performing the stencil transformation.
 \param ex Execution policy object.
-\param firsts Tuple of iterator to the first elements of the input sequences.
-\param size Size of the input sequence to be proccess.
+\param first Iterator to the first element in the input sequence.
+\param last Iterator to one past the end of the input sequence.
 \param out Iterator to the first element in the output sequence.
 \param transform_op Stencil transformation operation.
 \param neighbour_op Neighbourhood operation.
 */
-template <typename Execution, typename ...InputIterators, typename OutputIt,
+template <typename Execution, typename InputIt, typename OutputIt, 
           typename StencilTransformer, typename Neighbourhood,
-          requires_iterators<InputIterators...> = 0,
+          requires_iterator<InputIt> = 0,
           requires_iterator<OutputIt> = 0>
 void stencil(
-    const Execution & ex,
-    std::tuple<InputIterators...> firsts, std::size_t size, OutputIt out,
-    StencilTransformer && transform_op,
-    Neighbourhood && neighbour_op)
+    const Execution & ex, 
+    InputIt first, InputIt last, OutputIt out, 
+    StencilTransformer && transform_op, 
+    Neighbourhood && neighbour_op) 
 {
   static_assert(supports_stencil<Execution>(),
-                "stencil not supported for execution type");
-  ex.stencil(firsts, out, size,
-             std::forward<StencilTransformer>(transform_op),
-             std::forward<Neighbourhood>(neighbour_op));
+      "stencil not supported for execution type");
+  ex.stencil(std::make_tuple(first), out,
+      std::distance(first,last),
+      std::forward<StencilTransformer>(transform_op),
+      std::forward<Neighbourhood>(neighbour_op));
 }
 
 /**
@@ -174,7 +175,7 @@ sequential execution.
 \tparam StencilTransformer Callable type for performing the stencil transformation.
 \param ex Execution policy object.
 \param first Iterator to the first element in the input sequence.
-\param last Iterator to one past the end of the input sequence.
+\param size Size of the input sequence to be proccessed.
 \param out Iterator to the first element in the output sequence.
 \param transform_op Stencil transformation operation.
 \param neighbour_op Neighbourhood operation.
@@ -185,16 +186,48 @@ template <typename Execution, typename InputIt, typename OutputIt,
           requires_iterator<OutputIt> = 0>
 void stencil(
     const Execution & ex, 
-    InputIt first, InputIt last, OutputIt out, 
+    InputIt first, std::size_t size, OutputIt out, 
     StencilTransformer && transform_op, 
     Neighbourhood && neighbour_op) 
 {
   static_assert(supports_stencil<Execution>(),
       "stencil not supported for execution type");
   ex.stencil(std::make_tuple(first), out,
-      std::distance(first,last),
+      size,
       std::forward<StencilTransformer>(transform_op),
       std::forward<Neighbourhood>(neighbour_op));
+}
+
+/**
+\brief Invoke \ref md_stencil on a data sequence with
+sequential execution.
+\tparam Execution Execution type.
+\tparam InputIterators Iterators types used for the input sequences.
+\tparam OutputIt Iterator type used for the output sequence
+\tparam StencilTransformer Callable type for performing the stencil transformation.
+\tparam Neighbourhood Callable type for obtaining the neighbourhood.
+\param ex Execution policy object.
+\param firsts Tuple of iterator to the first elements of the input sequences.
+\param size Size of the input sequence to be proccess.
+\param out Iterator to the first element in the output sequence.
+\param transform_op Stencil transformation operation.
+\param neighbour_op Neighbourhood operation.
+*/
+template <typename Execution, typename ...InputIterators, typename OutputIt,
+          typename StencilTransformer, typename Neighbourhood,
+          requires_iterators<InputIterators...> = 0,
+          requires_iterator<OutputIt> = 0>
+void stencil(
+    const Execution & ex,
+    std::tuple<InputIterators...> firsts, std::size_t size, OutputIt out,
+    StencilTransformer && transform_op,
+    Neighbourhood && neighbour_op)
+{
+  static_assert(supports_stencil<Execution>(),
+                "stencil not supported for execution type");
+  ex.stencil(firsts, out, size,
+             std::forward<StencilTransformer>(transform_op),
+             std::forward<Neighbourhood>(neighbour_op));
 }
 
 /**
@@ -213,6 +246,7 @@ sequential execution.
 \param transform_op Stencil transformation operation.
 \param neighbour_op Neighbourhood operation.
 \param other_firsts Iterators to the first element of additional input sequences.
+\deprecated For multiple inputs, use a tuple or zip versions.
 */
 template <typename Execution, typename InputIt, typename OutputIt, 
           typename StencilTransformer, typename Neighbourhood, 
@@ -220,7 +254,7 @@ template <typename Execution, typename InputIt, typename OutputIt,
           requires_iterator<InputIt> = 0,
           requires_iterator<OutputIt> = 0>
 [[deprecated("This version of the interface is deprecated.\n"
-             "If you want to use multiple inputs, use a tuple instead.")]]
+             "For multiple inputs, use a tuple or zip versions.")]]
 void stencil(
     const Execution & ex, 
     InputIt first, InputIt last, OutputIt out, 

--- a/include/stencil.h
+++ b/include/stencil.h
@@ -19,7 +19,7 @@
 #include <tuple>
 #include <utility>
 
-#include "range_mapping.h"
+#include "common/zip_view.h"
 #include "common/execution_traits.h"
 #include "common/iterator_traits.h"
 

--- a/include/stencil.h
+++ b/include/stencil.h
@@ -50,8 +50,8 @@ sequential execution.
 */
 template <typename Execution, typename InputRange, typename OutputRange, 
           typename StencilTransformer, typename Neighbourhood,
-          requires_range<InputRange> = 0,
-          requires_range<OutputRange> = 0>
+          meta::requires<range_concept,InputRange> = 0,
+          meta::requires<range_concept,OutputRange> = 0>
 void stencil(
     const Execution & ex, 
     InputRange rin, OutputRange rout,
@@ -83,8 +83,8 @@ sequential execution.
 */
 template <typename Execution, typename ... InputRanges, typename OutputRange,
           typename StencilTransformer, typename Neighbourhood,
-          requires_ranges<InputRanges...> = 0,
-          requires_range<OutputRange> = 0>
+          meta::requires<range_concept,InputRanges...> = 0,
+          meta::requires<range_concept,OutputRange> = 0>
 void stencil(
     const Execution & ex,
     std::tuple<InputRanges...> rins, OutputRange rout,

--- a/include/stencil.h
+++ b/include/stencil.h
@@ -37,14 +37,13 @@ namespace grppi {
 \brief Invoke \ref md_stencil on a data sequence with 
 sequential execution.
 \tparam Execution Execution type.
-\tparam InputIt Iterator type used for the input sequence.
-\tparam OutputIt Iterator type used for the output sequence
+\tparam InputRange Range type used for the input sequence.
+\tparam OutputRange Range type used for the output sequence
 \tparam Neighbourhood Callable type for obtaining the neighbourhood.
 \tparam StencilTransformer Callable type for performing the stencil transformation.
 \param ex Execution policy object.
-\param first Iterator to the first element in the input sequence.
-\param last Iterator to one past the end of the input sequence.
-\param out Iterator to the first element in the output sequence.
+\param rin Range for the input sequence.
+\param rout Range for the output sequence.
 \param transform_op Stencil transformation operation.
 \param neighbour_op Neighbourhood operation.
 */
@@ -70,14 +69,13 @@ void stencil(
 \brief Invoke \ref md_stencil on a data sequence with
 sequential execution.
 \tparam Execution Execution type.
-\tparam InputIterators Iterators types used for the input sequences.
-\tparam OutputIt Iterator type used for the output sequence
+\tparam InputRanges Range types used for the input sequences.
+\tparam OutputRange Range type used for the output sequence
 \tparam StencilTransformer Callable type for performing the stencil transformation.
 \tparam Neighbourhood Callable type for obtaining the neighbourhood.
 \param ex Execution policy object.
-\param firsts Tuple of iterator to the first elements of the input sequences.
-\param size Size of the input sequence to be proccess.
-\param out Iterator to the first element in the output sequence.
+\param rins Zip view for the input sequences.
+\param rout Range for the output sequence.
 \param transform_op Stencil transformation operation.
 \param neighbour_op Neighbourhood operation.
 */

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -37,6 +37,11 @@ endif()
 if(GRPPI_UNIT_TEST_ENABLE)
   include_directories(${GTEST_INCLUDE_DIRS})
 
+  if ( NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") )
+    # Add coverage options. Needs to be done before add_executable
+    add_compile_options(--coverage)
+  endif()
+
   set(PROJECT_TEST_NAME utest_${PROJECT_NAME_STR})
   file(GLOB TEST_SRC_FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/*cpp)
@@ -44,11 +49,6 @@ if(GRPPI_UNIT_TEST_ENABLE)
   
   # Unit testing should be made in debug mode
   set(CMAKE_BUILD_TYPE "Debug")
-
-  if ( NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") )
-    # Add coverage options
-    add_compile_options(--coverage)
-  endif()
 
   # Do not emit deprecated warnings for _legacy unit tests
   file(GLOB TEST_SRC_FILES_LEGACY

--- a/unit_tests/map.cpp
+++ b/unit_tests/map.cpp
@@ -112,8 +112,8 @@ public:
   }
 
   void check_single_unary() {
-    EXPECT_EQ(1, this->invocations); // one invocation
-    EXPECT_EQ(84, this->w[0]);
+    EXPECT_EQ(1, invocations); // one invocation
+    EXPECT_EQ(84, w[0]);
   }
 
   void setup_multiple_unary() {
@@ -123,8 +123,8 @@ public:
   }
 
   void check_multiple_unary() {
-    EXPECT_EQ(5, this->invocations); // five invocations
-    EXPECT_TRUE(equal(begin(this->expected), end(this->expected), begin(this->w)));
+    EXPECT_EQ(5, invocations); // five invocations
+    EXPECT_TRUE(equal(begin(expected), end(expected), begin(w)));
   }
 
   void setup_single_nary() {
@@ -135,8 +135,8 @@ public:
   }
 
   void check_single_nary() {
-    EXPECT_EQ(1, this->invocations); // one invocation
-    EXPECT_EQ(66, this->w[0]);
+    EXPECT_EQ(1, invocations); // one invocation
+    EXPECT_EQ(66, w[0]);
   }
 
   void setup_multiple_nary() {
@@ -148,8 +148,8 @@ public:
   }
 
   void check_multiple_nary() {
-    EXPECT_EQ(5, this->invocations); // five invocations
-    EXPECT_TRUE(equal(begin(this->expected), end(this->expected), begin(this->w)));
+    EXPECT_EQ(5, invocations); // five invocations
+    EXPECT_TRUE(equal(begin(expected), end(expected), begin(w)));
   }
 
 };

--- a/unit_tests/map.cpp
+++ b/unit_tests/map.cpp
@@ -55,7 +55,7 @@ public:
   template <typename E>
   void run_unary_range(const E & e) {
     grppi::map(e,
-      grppi::make_range(v), grppi::make_range(w),
+      v, w,
       [this](int i) {
         invocations++;
         return i*2;
@@ -90,8 +90,8 @@ public:
   template<typename E>
   void run_nary_tuple_range(const E & e) {
     grppi::map(e,
-      grppi::make_ranges(v,v2,v3),
-      grppi::make_range(w),
+      grppi::zip(v,v2,v3),
+      w,
        [this](int x, int y, int z){
          invocations++;
          return x+y+z;

--- a/unit_tests/map.cpp
+++ b/unit_tests/map.cpp
@@ -53,6 +53,17 @@ public:
   }
 
   template <typename E>
+  void run_unary_size(const E & e) {
+    grppi::map(e, 
+      v.begin(), v.size(), w.begin(),
+      [this](int i) {
+        invocations++; 
+        return i*2; 
+      }
+    );
+  }
+
+  template <typename E>
   void run_unary_range(const E & e) {
     grppi::map(e,
       v, w,
@@ -164,6 +175,13 @@ TYPED_TEST(map_test, static_empty_unary)
   this->check_empty();
 }
 
+TYPED_TEST(map_test, static_empty_unary_size)
+{
+  this->setup_empty();
+  this->run_unary_size(this->execution_);
+  this->check_empty();
+}
+
 TYPED_TEST(map_test, static_empty_unary_range)
 {
   this->setup_empty();
@@ -175,6 +193,13 @@ TYPED_TEST(map_test, dyn_empty_unary)
 {
   this->setup_empty();
   this->run_unary(this->dyn_execution_);
+  this->check_empty();
+}
+
+TYPED_TEST(map_test, dyn_empty_unary_size)
+{
+  this->setup_empty();
+  this->run_unary_size(this->dyn_execution_);
   this->check_empty();
 }
 
@@ -192,6 +217,13 @@ TYPED_TEST(map_test, static_single_unary)
   this->check_single_unary();
 }
 
+TYPED_TEST(map_test, static_single_unary_size)
+{
+  this->setup_single_unary();
+  this->run_unary_size(this->execution_);
+  this->check_single_unary();
+}
+
 TYPED_TEST(map_test, static_single_unary_range)
 {
   this->setup_single_unary();
@@ -203,6 +235,13 @@ TYPED_TEST(map_test, dyn_single_unary)
 {
   this->setup_single_unary();
   this->run_unary(this->dyn_execution_);
+  this->check_single_unary();
+}
+
+TYPED_TEST(map_test, dyn_single_unary_size)
+{
+  this->setup_single_unary();
+  this->run_unary_size(this->dyn_execution_);
   this->check_single_unary();
 }
 
@@ -220,6 +259,13 @@ TYPED_TEST(map_test, static_multiple_unary)
   this->check_multiple_unary();
 }
 
+TYPED_TEST(map_test, static_multiple_unary_size)
+{
+  this->setup_multiple_unary();
+  this->run_unary_size(this->execution_);
+  this->check_multiple_unary();
+}
+
 TYPED_TEST(map_test, static_multiple_unary_range)
 {
   this->setup_multiple_unary();
@@ -231,6 +277,13 @@ TYPED_TEST(map_test, dyn_multiple_unary)
 {
   this->setup_multiple_unary();
   this->run_unary(this->dyn_execution_);
+  this->check_multiple_unary();
+}
+
+TYPED_TEST(map_test, dyn_multiple_unary_size)
+{
+  this->setup_multiple_unary();
+  this->run_unary_size(this->dyn_execution_);
   this->check_multiple_unary();
 }
 

--- a/unit_tests/map.cpp
+++ b/unit_tests/map.cpp
@@ -53,7 +53,18 @@ public:
   }
 
   template <typename E>
-  void run_nary_tuple_range(const E &e) {
+  void run_unary_range(const E & e) {
+    grppi::map(e,
+      grppi::make_range(v), grppi::make_range(w),
+      [this](int i) {
+        invocations++;
+        return i*2;
+      }
+    );
+  }
+
+  template <typename E>
+  void run_nary_tuple_iter(const E &e) {
     grppi::map(e, 
       make_tuple(v.begin(),v2.begin(),v3.begin()),
       v.end(), w.begin(),
@@ -69,6 +80,18 @@ public:
     grppi::map(e,
       make_tuple(v.begin(),v2.begin(),v3.begin()),
       v.size(), w.begin(),
+       [this](int x, int y, int z){
+         invocations++;
+         return x+y+z;
+       }
+    );
+  }
+
+  template<typename E>
+  void run_nary_tuple_range(const E & e) {
+    grppi::map(e,
+      grppi::make_ranges(v,v2,v3),
+      grppi::make_range(w),
        [this](int x, int y, int z){
          invocations++;
          return x+y+z;
@@ -141,10 +164,24 @@ TYPED_TEST(map_test, static_empty_unary)
   this->check_empty();
 }
 
+TYPED_TEST(map_test, static_empty_unary_range)
+{
+  this->setup_empty();
+  this->run_unary_range(this->execution_);
+  this->check_empty();
+}
+
 TYPED_TEST(map_test, dyn_empty_unary)
 {
   this->setup_empty();
   this->run_unary(this->dyn_execution_);
+  this->check_empty();
+}
+
+TYPED_TEST(map_test, dyn_empty_unary_range)
+{
+  this->setup_empty();
+  this->run_unary_range(this->dyn_execution_);
   this->check_empty();
 }
 
@@ -155,10 +192,24 @@ TYPED_TEST(map_test, static_single_unary)
   this->check_single_unary();
 }
 
+TYPED_TEST(map_test, static_single_unary_range)
+{
+  this->setup_single_unary();
+  this->run_unary_range(this->execution_);
+  this->check_single_unary();
+}
+
 TYPED_TEST(map_test, dyn_single_unary)
 {
   this->setup_single_unary();
   this->run_unary(this->dyn_execution_);
+  this->check_single_unary();
+}
+
+TYPED_TEST(map_test, dyn_single_unary_range)
+{
+  this->setup_single_unary();
+  this->run_unary_range(this->dyn_execution_);
   this->check_single_unary();
 }
 
@@ -169,6 +220,13 @@ TYPED_TEST(map_test, static_multiple_unary)
   this->check_multiple_unary();
 }
 
+TYPED_TEST(map_test, static_multiple_unary_range)
+{
+  this->setup_multiple_unary();
+  this->run_unary_range(this->execution_);
+  this->check_multiple_unary();
+}
+
 TYPED_TEST(map_test, dyn_multiple_unary)
 {
   this->setup_multiple_unary();
@@ -176,6 +234,26 @@ TYPED_TEST(map_test, dyn_multiple_unary)
   this->check_multiple_unary();
 }
 
+TYPED_TEST(map_test, dyn_multiple_unary_range)
+{
+  this->setup_multiple_unary();
+  this->run_unary_range(this->dyn_execution_);
+  this->check_multiple_unary();
+}
+
+TYPED_TEST(map_test, static_empty_nary_tuple_iter)
+{
+  this->setup_empty();
+  this->run_nary_tuple_iter(this->execution_);
+  this->check_empty();
+}
+
+TYPED_TEST(map_test, static_empty_nary_tuple_size)
+{
+  this->setup_empty();
+  this->run_nary_tuple_size(this->execution_);
+  this->check_empty();
+}
 
 TYPED_TEST(map_test, static_empty_nary_tuple_range)
 {
@@ -184,46 +262,10 @@ TYPED_TEST(map_test, static_empty_nary_tuple_range)
   this->check_empty();
 }
 
-TYPED_TEST(map_test, dyn_empty_nary_tuple_range)
+TYPED_TEST(map_test, dyn_empty_nary_tuple_iter)
 {
   this->setup_empty();
-  this->run_nary_tuple_range(this->dyn_execution_);
-  this->check_empty();
-}
-
-TYPED_TEST(map_test, static_single_nary_tuple_range)
-{
-  this->setup_single_nary();
-  this->run_nary_tuple_range(this->execution_);
-  this->check_single_nary();
-}
-
-TYPED_TEST(map_test, dyn_single_nary_tuple_range)
-{
-  this->setup_single_nary();
-  this->run_nary_tuple_range(this->dyn_execution_);
-  this->check_single_nary();
-}
-
-TYPED_TEST(map_test, static_multiple_nary_tuple_range)
-{
-  this->setup_multiple_nary();
-  this->run_nary_tuple_range(this->execution_);
-  this->check_multiple_nary();
-}
-
-TYPED_TEST(map_test, dyn_multiple_nary_tuple_range)
-{
-  this->setup_multiple_nary();
-  this->run_nary_tuple_range(this->execution_);
-  this->check_multiple_nary();
-}
-
-
-TYPED_TEST(map_test, static_empty_nary_tuple_size)
-{
-  this->setup_empty();
-  this->run_nary_tuple_size(this->execution_);
+  this->run_nary_tuple_iter(this->dyn_execution_);
   this->check_empty();
 }
 
@@ -234,10 +276,38 @@ TYPED_TEST(map_test, dyn_empty_nary_tuple_size)
   this->check_empty();
 }
 
+TYPED_TEST(map_test, dyn_empty_nary_tuple_range)
+{
+  this->setup_empty();
+  this->run_nary_tuple_range(this->dyn_execution_);
+  this->check_empty();
+}
+
+TYPED_TEST(map_test, static_single_nary_tuple_iter)
+{
+  this->setup_single_nary();
+  this->run_nary_tuple_iter(this->execution_);
+  this->check_single_nary();
+}
+
 TYPED_TEST(map_test, static_single_nary_tuple_size)
 {
   this->setup_single_nary();
   this->run_nary_tuple_size(this->execution_);
+  this->check_single_nary();
+}
+
+TYPED_TEST(map_test, static_single_nary_tuple_range)
+{
+  this->setup_single_nary();
+  this->run_nary_tuple_range(this->execution_);
+  this->check_single_nary();
+}
+
+TYPED_TEST(map_test, dyn_single_nary_tuple_iter)
+{
+  this->setup_single_nary();
+  this->run_nary_tuple_iter(this->dyn_execution_);
   this->check_single_nary();
 }
 
@@ -248,10 +318,38 @@ TYPED_TEST(map_test, dyn_single_nary_tuple_size)
   this->check_single_nary();
 }
 
+TYPED_TEST(map_test, dyn_single_nary_tuple_range)
+{
+  this->setup_single_nary();
+  this->run_nary_tuple_range(this->dyn_execution_);
+  this->check_single_nary();
+}
+
+TYPED_TEST(map_test, static_multiple_nary_tuple_iter)
+{
+  this->setup_multiple_nary();
+  this->run_nary_tuple_iter(this->execution_);
+  this->check_multiple_nary();
+}
+
 TYPED_TEST(map_test, static_multiple_nary_tuple_size)
 {
   this->setup_multiple_nary();
   this->run_nary_tuple_size(this->execution_);
+  this->check_multiple_nary();
+}
+
+TYPED_TEST(map_test, static_multiple_nary_tuple_range)
+{
+  this->setup_multiple_nary();
+  this->run_nary_tuple_range(this->execution_);
+  this->check_multiple_nary();
+}
+
+TYPED_TEST(map_test, dyn_multiple_nary_tuple_iter)
+{
+  this->setup_multiple_nary();
+  this->run_nary_tuple_iter(this->execution_);
   this->check_multiple_nary();
 }
 
@@ -261,3 +359,11 @@ TYPED_TEST(map_test, dyn_multiple_nary_tuple_size)
   this->run_nary_tuple_size(this->execution_);
   this->check_multiple_nary();
 }
+
+TYPED_TEST(map_test, dyn_multiple_nary_tuple_range)
+{
+  this->setup_multiple_nary();
+  this->run_nary_tuple_range(this->execution_);
+  this->check_multiple_nary();
+}
+

--- a/unit_tests/mapreduce.cpp
+++ b/unit_tests/mapreduce.cpp
@@ -57,7 +57,7 @@ public:
 
   template <typename E>
   auto run_square_sum_range(const E & e) {
-    return grppi::map_reduce(e, grppi::make_range(v), 0,
+    return grppi::map_reduce(e, v, 0,
       [this](int x) { 
         invocations_transformer++; 
         return x*x;
@@ -99,7 +99,7 @@ public:
   template <typename E>
   auto run_scalar_product_tuple_range(const E & e){
     return  grppi::map_reduce(e,
-      make_ranges(v,v2), 0,
+      grppi::zip(v,v2), 0,
       [this](int x1, int x2) {
         invocations_transformer++;
         return x1 * x2;

--- a/unit_tests/mapreduce.cpp
+++ b/unit_tests/mapreduce.cpp
@@ -56,7 +56,20 @@ public:
   }
 
   template <typename E>
-  auto run_scalar_product_tuple_range(const E & e){
+  auto run_square_sum_range(const E & e) {
+    return grppi::map_reduce(e, grppi::make_range(v), 0,
+      [this](int x) { 
+        invocations_transformer++; 
+        return x*x;
+      },
+      [](int x, int y) { 
+        return x + y; 
+      }
+    );
+  }
+
+  template <typename E>
+  auto run_scalar_product_tuple_iter(const E & e){
     return  grppi::map_reduce(e,
       make_tuple(v.begin(),v2.begin()), v.end(), 0,
       [this](int x1, int x2) {
@@ -82,6 +95,21 @@ public:
       }
     );
   }
+
+  template <typename E>
+  auto run_scalar_product_tuple_range(const E & e){
+    return  grppi::map_reduce(e,
+      make_ranges(v,v2), 0,
+      [this](int x1, int x2) {
+        invocations_transformer++;
+        return x1 * x2;
+      },
+      [](int x, int y){
+        return x + y;
+      }
+    );
+  }
+
   
   void setup_single() {
     v = vector<int>{1};
@@ -137,6 +165,13 @@ TYPED_TEST(map_reduce_test, static_single_square_sum)
   this->check_single();
 }
 
+TYPED_TEST(map_reduce_test, static_single_square_sum_range)
+{
+  this->setup_single();
+  this->output = this->run_square_sum_range(this->execution_);
+  this->check_single();
+}
+
 TYPED_TEST(map_reduce_test, dyn_single_square_sum)
 {
   this->setup_single();
@@ -144,12 +179,24 @@ TYPED_TEST(map_reduce_test, dyn_single_square_sum)
   this->check_single();
 }
 
-
+TYPED_TEST(map_reduce_test, dyn_single_square_sum_range)
+{
+  this->setup_single();
+  this->output = this->run_square_sum_range(this->dyn_execution_);
+  this->check_single();
+}
 
 TYPED_TEST(map_reduce_test, static_multiple_square_sum)
 {
   this->setup_multiple();
   this->output = this->run_square_sum(this->execution_);
+  this->check_multiple();
+}
+
+TYPED_TEST(map_reduce_test, static_multiple_square_sum_range)
+{
+  this->setup_multiple();
+  this->output = this->run_square_sum_range(this->execution_);
   this->check_multiple();
 }
 
@@ -160,7 +207,26 @@ TYPED_TEST(map_reduce_test, dyn_multiple_square_sum)
   this->check_multiple();
 }
 
+TYPED_TEST(map_reduce_test, dyn_multiple_square_sum_range)
+{
+  this->setup_multiple();
+  this->output = this->run_square_sum_range(this->dyn_execution_);
+  this->check_multiple();
+}
 
+TYPED_TEST(map_reduce_test, static_single_scalar_product_tuple_iter)
+{
+  this->setup_single_scalar_product();
+  this->output = this->run_scalar_product_tuple_iter(this->execution_);
+  this->check_single_scalar_product();
+}
+
+TYPED_TEST(map_reduce_test, static_single_scalar_product_tuple_size)
+{
+  this->setup_single_scalar_product();
+  this->output = this->run_scalar_product_tuple_size(this->execution_);
+  this->check_single_scalar_product();
+}
 
 TYPED_TEST(map_reduce_test, static_single_scalar_product_tuple_range)
 {
@@ -169,35 +235,10 @@ TYPED_TEST(map_reduce_test, static_single_scalar_product_tuple_range)
   this->check_single_scalar_product();
 }
 
-TYPED_TEST(map_reduce_test, dyn_single_scalar_product_tuple_range)
+TYPED_TEST(map_reduce_test, dyn_single_scalar_product_tuple_iter)
 {
   this->setup_single_scalar_product();
-  this->output = this->run_scalar_product_tuple_range(this->dyn_execution_);
-  this->check_single_scalar_product();
-}
-
-
-
-TYPED_TEST(map_reduce_test, static_multiple_scalar_product_tuple_range)
-{
-  this->setup_multiple_scalar_product();
-  this->output = this->run_scalar_product_tuple_range(this->execution_);
-  this->check_multiple_scalar_product();
-}
-
-TYPED_TEST(map_reduce_test, dyn_multiple_scalar_product_tuple_range)
-{
-  this->setup_multiple_scalar_product();
-  this->output = this->run_scalar_product_tuple_range(this->dyn_execution_);
-  this->check_multiple_scalar_product();
-}
-
-
-
-TYPED_TEST(map_reduce_test, static_single_scalar_product_tuple_size)
-{
-  this->setup_single_scalar_product();
-  this->output = this->run_scalar_product_tuple_size(this->execution_);
+  this->output = this->run_scalar_product_tuple_iter(this->dyn_execution_);
   this->check_single_scalar_product();
 }
 
@@ -208,7 +249,19 @@ TYPED_TEST(map_reduce_test, dyn_single_scalar_product_tuple_size)
   this->check_single_scalar_product();
 }
 
+TYPED_TEST(map_reduce_test, dyn_single_scalar_product_tuple_range)
+{
+  this->setup_single_scalar_product();
+  this->output = this->run_scalar_product_tuple_range(this->dyn_execution_);
+  this->check_single_scalar_product();
+}
 
+TYPED_TEST(map_reduce_test, static_multiple_scalar_product_tuple_iter)
+{
+  this->setup_multiple_scalar_product();
+  this->output = this->run_scalar_product_tuple_iter(this->execution_);
+  this->check_multiple_scalar_product();
+}
 
 TYPED_TEST(map_reduce_test, static_multiple_scalar_product_tuple_size)
 {
@@ -217,9 +270,30 @@ TYPED_TEST(map_reduce_test, static_multiple_scalar_product_tuple_size)
   this->check_multiple_scalar_product();
 }
 
+TYPED_TEST(map_reduce_test, static_multiple_scalar_product_tuple_range)
+{
+  this->setup_multiple_scalar_product();
+  this->output = this->run_scalar_product_tuple_range(this->execution_);
+  this->check_multiple_scalar_product();
+}
+
+TYPED_TEST(map_reduce_test, dyn_multiple_scalar_product_tuple_iter)
+{
+  this->setup_multiple_scalar_product();
+  this->output = this->run_scalar_product_tuple_iter(this->dyn_execution_);
+  this->check_multiple_scalar_product();
+}
+
 TYPED_TEST(map_reduce_test, dyn_multiple_scalar_product_tuple_size)
 {
   this->setup_multiple_scalar_product();
   this->output = this->run_scalar_product_tuple_size(this->dyn_execution_);
+  this->check_multiple_scalar_product();
+}
+
+TYPED_TEST(map_reduce_test, dyn_multiple_scalar_product_tuple_size_range)
+{
+  this->setup_multiple_scalar_product();
+  this->output = this->run_scalar_product_tuple_range(this->dyn_execution_);
   this->check_multiple_scalar_product();
 }

--- a/unit_tests/mapreduce.cpp
+++ b/unit_tests/mapreduce.cpp
@@ -56,6 +56,19 @@ public:
   }
 
   template <typename E>
+  auto run_square_sum_size(const E & e) {
+    return grppi::map_reduce(e, begin(v), v.size(), 0,
+      [this](int x) { 
+        invocations_transformer++; 
+        return x*x;
+      },
+      [](int x, int y) { 
+        return x + y; 
+      }
+    );
+  }
+
+  template <typename E>
   auto run_square_sum_range(const E & e) {
     return grppi::map_reduce(e, v, 0,
       [this](int x) { 
@@ -165,6 +178,13 @@ TYPED_TEST(map_reduce_test, static_single_square_sum)
   this->check_single();
 }
 
+TYPED_TEST(map_reduce_test, static_single_square_sum_size)
+{
+  this->setup_single();
+  this->output = this->run_square_sum_size(this->execution_);
+  this->check_single();
+}
+
 TYPED_TEST(map_reduce_test, static_single_square_sum_range)
 {
   this->setup_single();
@@ -176,6 +196,13 @@ TYPED_TEST(map_reduce_test, dyn_single_square_sum)
 {
   this->setup_single();
   this->output = this->run_square_sum(this->dyn_execution_);
+  this->check_single();
+}
+
+TYPED_TEST(map_reduce_test, dyn_single_square_sum_size)
+{
+  this->setup_single();
+  this->output = this->run_square_sum_size(this->dyn_execution_);
   this->check_single();
 }
 
@@ -193,6 +220,13 @@ TYPED_TEST(map_reduce_test, static_multiple_square_sum)
   this->check_multiple();
 }
 
+TYPED_TEST(map_reduce_test, static_multiple_square_sum_size)
+{
+  this->setup_multiple();
+  this->output = this->run_square_sum_size(this->execution_);
+  this->check_multiple();
+}
+
 TYPED_TEST(map_reduce_test, static_multiple_square_sum_range)
 {
   this->setup_multiple();
@@ -204,6 +238,13 @@ TYPED_TEST(map_reduce_test, dyn_multiple_square_sum)
 {
   this->setup_multiple();
   this->output = this->run_square_sum(this->dyn_execution_);
+  this->check_multiple();
+}
+
+TYPED_TEST(map_reduce_test, dyn_multiple_square_sum_size)
+{
+  this->setup_multiple();
+  this->output = this->run_square_sum_size(this->dyn_execution_);
   this->check_multiple();
 }
 

--- a/unit_tests/reduce.cpp
+++ b/unit_tests/reduce.cpp
@@ -53,7 +53,7 @@ public:
   
   template <typename E>
   void run_unary_range(const E & e) {
-    out = grppi::reduce(e, grppi::make_range(v), 0,
+    out = grppi::reduce(e, v, 0,
      [](int x, int y){ return x + y; }
     );
   }

--- a/unit_tests/reduce.cpp
+++ b/unit_tests/reduce.cpp
@@ -51,6 +51,13 @@ public:
     );
   }
   
+  template <typename E>
+  void run_unary_range(const E & e) {
+    out = grppi::reduce(e, grppi::make_range(v), 0,
+     [](int x, int y){ return x + y; }
+    );
+  }
+
   void setup_single() {
     out = 0;
     v = vector<int>{1};
@@ -81,35 +88,24 @@ TYPED_TEST(reduce_test, static_single)
   this->check_single();
 }
 
-TYPED_TEST(reduce_test, dyn_single)
-{
-  this->setup_single();
-  this->run_unary(this->dyn_execution_);
-  this->check_single();
-}
-
-
-
-TYPED_TEST(reduce_test, static_multiple)
-{
-  this->setup_multiple();
-  this->run_unary_size(this->execution_);
-  this->check_multiple();
-}
-
-TYPED_TEST(reduce_test, dyn_multiple)
-{
-  this->setup_multiple();
-  this->run_unary_size(this->dyn_execution_);
-  this->check_multiple();
-}
-
-
-
 TYPED_TEST(reduce_test, static_single_size)
 {
   this->setup_single();
   this->run_unary_size(this->execution_);
+  this->check_single();
+}
+
+TYPED_TEST(reduce_test, static_single_range)
+{
+  this->setup_single();
+  this->run_unary_range(this->execution_);
+  this->check_single();
+}
+
+TYPED_TEST(reduce_test, dyn_single)
+{
+  this->setup_single();
+  this->run_unary(this->dyn_execution_);
   this->check_single();
 }
 
@@ -120,7 +116,19 @@ TYPED_TEST(reduce_test, dyn_single_size)
   this->check_single();
 }
 
+TYPED_TEST(reduce_test, dyn_single_range)
+{
+  this->setup_single();
+  this->run_unary_range(this->dyn_execution_);
+  this->check_single();
+}
 
+TYPED_TEST(reduce_test, static_multiple)
+{
+  this->setup_multiple();
+  this->run_unary_size(this->execution_);
+  this->check_multiple();
+}
 
 TYPED_TEST(reduce_test, static_multiple_size)
 {
@@ -129,9 +137,30 @@ TYPED_TEST(reduce_test, static_multiple_size)
   this->check_multiple();
 }
 
+TYPED_TEST(reduce_test, static_multiple_range)
+{
+  this->setup_multiple();
+  this->run_unary_range(this->execution_);
+  this->check_multiple();
+}
+
+TYPED_TEST(reduce_test, dyn_multiple)
+{
+  this->setup_multiple();
+  this->run_unary_size(this->dyn_execution_);
+  this->check_multiple();
+}
+
 TYPED_TEST(reduce_test, dyn_multiple_size)
 {
   this->setup_multiple();
   this->run_unary_size(this->dyn_execution_);
+  this->check_multiple();
+}
+
+TYPED_TEST(reduce_test, dyn_multiple_range)
+{
+  this->setup_multiple();
+  this->run_unary_range(this->dyn_execution_);
   this->check_multiple();
 }

--- a/unit_tests/stencil.cpp
+++ b/unit_tests/stencil.cpp
@@ -65,7 +65,7 @@ public:
 
   template <typename E>
   void run_unary_range(E & ex) {
-    grppi::stencil(ex, make_range(v), make_range(w),
+    grppi::stencil(ex, v, w,
       [this](auto it, auto n) { 
         invocations_operation++; 
         return *it + n;
@@ -187,7 +187,7 @@ public:
       return result;
     };
 
-    grppi::stencil(ex, make_ranges(v,v2), make_range(w),
+    grppi::stencil(ex, grppi::zip(v,v2), w,
       // Stencil computes average of neighbours
       [this](auto, const auto & n) {
         invocations_operation++;

--- a/unit_tests/stencil.cpp
+++ b/unit_tests/stencil.cpp
@@ -64,6 +64,24 @@ public:
   }
 
   template <typename E>
+  void run_unary_size(E & ex) {
+    grppi::stencil(ex, begin(v), v.size(), begin(w),
+      [this](auto it, auto n) { 
+        invocations_operation++; 
+        return *it + n;
+      },
+      [&](auto it) { 
+        invocations_neighbour++;
+        if (it+1 != v.end()) {
+          return *(it+1);
+        }
+        else {
+          return 0; 
+        }
+      }
+    );
+  }
+  template <typename E>
   void run_unary_range(E & ex) {
     grppi::stencil(ex, v, w,
       [this](auto it, auto n) { 
@@ -270,6 +288,13 @@ TYPED_TEST(stencil_test, static_empty)
   this->check_empty();
 }
 
+TYPED_TEST(stencil_test, static_empty_size)
+{
+  this->setup_empty();
+  this->run_unary_size(this->execution_);
+  this->check_empty();
+}
+
 TYPED_TEST(stencil_test, static_empty_range)
 {
   this->setup_empty();
@@ -281,6 +306,13 @@ TYPED_TEST(stencil_test, dyn_empty)
 {
   this->setup_empty();
   this->run_unary(this->dyn_execution_);
+  this->check_empty();
+}
+
+TYPED_TEST(stencil_test, dyn_empty_size)
+{
+  this->setup_empty();
+  this->run_unary_size(this->dyn_execution_);
   this->check_empty();
 }
 
@@ -342,6 +374,13 @@ TYPED_TEST(stencil_test, static_single)
   this->check_single();
 }
 
+TYPED_TEST(stencil_test, static_single_size)
+{
+  this->setup_single();
+  this->run_unary_size(this->execution_);
+  this->check_single();
+}
+
 TYPED_TEST(stencil_test, static_single_range)
 {
   this->setup_single();
@@ -353,6 +392,13 @@ TYPED_TEST(stencil_test, dyn_single)
 {
   this->setup_single();
   this->run_unary(this->dyn_execution_);
+  this->check_single();
+}
+
+TYPED_TEST(stencil_test, dyn_single_size)
+{
+  this->setup_single();
+  this->run_unary_size(this->dyn_execution_);
   this->check_single();
 }
 
@@ -414,6 +460,13 @@ TYPED_TEST(stencil_test, static_multiple)
   this->check_multiple();
 }
 
+TYPED_TEST(stencil_test, static_multiple_size)
+{
+  this->setup_multiple();
+  this->run_unary_size(this->execution_);
+  this->check_multiple();
+}
+
 TYPED_TEST(stencil_test, static_multiple_range)
 {
   this->setup_multiple();
@@ -425,6 +478,13 @@ TYPED_TEST(stencil_test, dyn_multiple)
 {
   this->setup_multiple();
   this->run_unary(this->dyn_execution_);
+  this->check_multiple();
+}
+
+TYPED_TEST(stencil_test, dyn_multiple_size)
+{
+  this->setup_multiple();
+  this->run_unary_size(this->dyn_execution_);
   this->check_multiple();
 }
 


### PR DESCRIPTION
Added new overloads of map, reduce, map/reduce, and stencil that accept a range. A range is any type having a begin(), end(), and size().

This allows to pass containers directly to the patterns.