### PR TITLE
Fix include error on MacOS

### DIFF
--- a/include/grppi/native/worker_pool.h
+++ b/include/grppi/native/worker_pool.h
@@ -17,6 +17,7 @@
 #define GRPPI_NATIVE_WORKER_POOL_H
 
 #include <thread>
+#include <vector>
 
 namespace grppi {
 


### PR DESCRIPTION
```std::vector<std::thread> workers_``` is used in ```worker_pool.h```, but the file doesn't include the vector library.

I was actually unable to compile a pipeline pattern without the addition of this line. I was getting this error:
```
include/grppi/dyn/../native/worker_pool.h:88:30: error: implicit instantiation of
      undefined template 'std::__1::vector<std::__1::thread,
      std::__1::allocator<std::__1::thread> >'
    std::vector<std::thread> workers_;
```
This PR fixes this error for me, hopefully it will help other users too.