### PR TITLE
adjustments for tbb's lack of contetx pattern support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,14 @@ project(${PROJECT_NAME_STR})
 # Path for additional CMake modules
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake.modules)
 
-# Print processor and compiler 
+# Find packages
+include(FetchContent)
+# Handle new timestamp behaviour (see https://cmake.org/cmake/help/latest/policy/CMP0135.html)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+	cmake_policy(SET CMP0135 NEW)
+endif()
+
+# Print processor and compiler
 message(STATUS "Detected processor is " ${CMAKE_SYSTEM_PROCESSOR})
 message(STATUS "CMAKE_C_COMPILER: " ${CMAKE_C_COMPILER})
 message(STATUS "CMAKE_CXX_COMPILER: " ${CMAKE_CXX_COMPILER})

--- a/include/grppi/common/execution_traits.h
+++ b/include/grppi/common/execution_traits.h
@@ -84,5 +84,12 @@ constexpr bool supports_pipeline() { return false; }
 template <typename E>
 constexpr bool supports_stream_pool() { return false; }
 
+/**
+\brief Determines if an execution policy supports the context pattern.
+\note This must be specialized by every execution policy supporting the pattern.
+*/
+template <typename E>
+constexpr bool supports_context() { return false; }
+
 } // end namespace grppi
 #endif

--- a/include/grppi/common/meta.h
+++ b/include/grppi/common/meta.h
@@ -128,13 +128,12 @@ there is no type defined.
   template<typename Ret, typename F, typename Arg, typename... Rest>
   Arg input_type_t(Ret(F::*) (Arg, Rest...) const);
 
+  /* if it is a function object */
   template <typename F, class = std::enable_if_t<!std::is_pointer<F>::value>>
   decltype(input_type_t(&F::operator())) input_type_l(F);
 
+  /* if it is an actual function */
   template <typename F, class = std::enable_if_t<std::is_pointer<F>::value>>
-  decltype(input_type_t(std::declval<F>())) input_type_l(F);
-
-  template <typename F>
   decltype(input_type_t(std::declval<F>())) input_type_l(F);
 
   template <typename F>
@@ -142,7 +141,6 @@ there is no type defined.
 
   template <typename F>
   using output_type = std::invoke_result_t<F,input_type<F>>;
-
 
 }
 

--- a/include/grppi/context.h
+++ b/include/grppi/context.h
@@ -16,6 +16,10 @@
 #ifndef GRPPI_CONTEXT_H
 #define GRPPI_CONTEXT_H
 
+#include <utility>
+
+#include "grppi/common/execution_traits.h"
+
 #include "grppi/common/context.h"
 
 namespace grppi {
@@ -39,6 +43,8 @@ that can be composed in other streaming patterns.
 template <typename ExecutionPolicy, typename Transformer>
 auto run_with(ExecutionPolicy & ex, Transformer && transform_op)
 {
+    static_assert(supports_context<ExecutionPolicy>(),
+        "context not supported on execution type");
    return context_t<ExecutionPolicy,Transformer>{ex,
        std::forward<Transformer>(transform_op)};
 }

--- a/include/grppi/dyn/dynamic_execution.h
+++ b/include/grppi/dyn/dynamic_execution.h
@@ -292,6 +292,15 @@ constexpr bool supports_pipeline<dynamic_execution>() { return true; }
 template <>
 constexpr bool supports_stream_pool<dynamic_execution>() { return true; }
 
+/**
+\brief Determines if an execution policy supports the context pattern.
+\note Specialization for dynamic_execution.
+*/
+template <>
+constexpr bool supports_context<dynamic_execution>() {
+  return true;
+}
+
 
 #define GRPPI_TRY_PATTERN(E,PATTERN,...)\
 {\

--- a/include/grppi/native/parallel_execution_native.h
+++ b/include/grppi/native/parallel_execution_native.h
@@ -712,6 +712,13 @@ constexpr bool supports_pipeline<parallel_execution_native>() { return true; }
 template <>
 constexpr bool supports_stream_pool<parallel_execution_native>() { return true; }
 
+/**
+\brief Determines if an execution policy supports the context pattern.
+\note Specialization for parallel_execution_native.
+*/
+  template<>
+  constexpr bool supports_context<parallel_execution_native>() { return true; }
+
 template <typename ... InputIterators, typename OutputIterator, 
           typename Transformer>
 void parallel_execution_native::map(

--- a/include/grppi/omp/parallel_execution_omp.h
+++ b/include/grppi/omp/parallel_execution_omp.h
@@ -652,10 +652,17 @@ namespace grppi {
 
 /**
 \brief Determines if an execution policy supports the stream pool pattern.
-\note Specialization for parallel_execution_native.
+\note Specialization for parallel_execution_omp when GRPPI_OMP is enabled.
 */
   template<>
   constexpr bool supports_stream_pool<parallel_execution_omp>() { return true; }
+
+/**
+\brief Determines if an execution policy supports the context pattern.
+\note Specialization for parallel_execution_omp when GRPPI_OMP is enabled.
+*/
+  template<>
+  constexpr bool supports_context<parallel_execution_omp>() { return true; }
 
   template<typename ... InputIterators, typename OutputIterator,
       typename Transformer>

--- a/include/grppi/tbb/parallel_execution_tbb.h
+++ b/include/grppi/tbb/parallel_execution_tbb.h
@@ -592,7 +592,7 @@ namespace grppi {
 
 /**
 \brief Determines if an execution policy supports the stream pool pattern.
-\note Specialization for parallel_execution_native.
+\note Specialization for parallel_execution_omp when GRPPI_TBB is enabled.
 */
   template<>
   constexpr bool supports_stream_pool<parallel_execution_tbb>() { return true; }
@@ -824,15 +824,6 @@ namespace grppi {
       return pipe;
     }
 
-    template<typename F,
-        requires_farm<F> = 0>
-    decltype(auto) make_node(oneapi::tbb::flow::graph & g,
-        [[maybe_unused]] int cardinality,
-        F && f)
-    {
-      return make_node(g, f.cardinality(), std::forward<F>(f).transformer());
-    }
-
     template<typename P,
         requires_filter<P> = 0>
     decltype(auto) make_node(oneapi::tbb::flow::graph & g,
@@ -903,6 +894,23 @@ namespace grppi {
           });
       return node;
 
+    }
+
+    template<typename F,
+        requires_farm<F> = 0>
+    decltype(auto) make_node(oneapi::tbb::flow::graph & g,
+        [[maybe_unused]] int cardinality,
+        F && f)
+    {
+      return make_node(g, f.cardinality(), std::forward<F>(f).transformer());
+    }
+
+    template<typename C,
+        requires_context<C> = 0>
+    decltype(auto) make_node(oneapi::tbb::flow::graph & g,
+        int cardinality, C&& c)
+    {
+      return make_node(g, cardinality, std::forward<C>(c).transformer());
     }
 
     template<typename I, typename T, std::size_t ... N>

--- a/samples/context/capitalize_ctx/main.cpp
+++ b/samples/context/capitalize_ctx/main.cpp
@@ -27,6 +27,7 @@
 #include "grppi/pipeline.h"
 #include "grppi/farm.h"
 #include "grppi/context.h"
+#include "grppi/common/execution_traits.h"
 
 // Samples shared utilities
 #include "../../util/util.h"
@@ -36,6 +37,7 @@ void capitalize(grppi::dynamic_execution & ex,
 {
   using namespace std;
 
+  if constexpr (grppi::supports_context<decltype(ex)>()) {
   grppi::parallel_execution_native inner_ex{2};
 
   grppi::pipeline(ex,
@@ -59,6 +61,7 @@ void capitalize(grppi::dynamic_execution & ex,
       ofile << line << "\n";
     }
   );
+  }
 
 }
 

--- a/samples/farm/capitalize/main.cpp
+++ b/samples/farm/capitalize/main.cpp
@@ -43,14 +43,14 @@ void capitalize(grppi::dynamic_execution & e,
       else return {};
     },
     grppi::farm(4,
-      [](auto word) { 
+      [](std::string word) { 
         grppi::sequential_execution seq{};
         grppi::map(seq, begin(word), end(word), begin(word), [](char c) {
           return std::toupper(c);
         }); 
         return word;
       }),
-    [&](auto word) {
+    [&](std::string word) {
       out << word << std::endl;
     }
   );

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -22,16 +22,26 @@ if(GRPPI_UNIT_TEST_ENABLE)
   if(POLICY CMP0057)
     cmake_policy(SET CMP0057 NEW)
   endif()
+
+  # Try to find GTest, otherwise fetch it from its repository and retry to find
   find_package(GTest)
   if(GTEST_FOUND)
     message(STATUS "GTest found")
   else()
-    set(GRPPI_UNIT_TEST_ENABLE OFF CACHE BOOL "Activate unit tests" FORCE)
-    message(STATUS "GTest not found")
-    message(STATUS "  GRPPI_UNIT_TEST_ENABLE has been set to OFF")
-    message(STATUS "  To enable unit tests, please, download and instal Google Test")
-    message(STATUS "  https://github.com/google/googletest")
+    message(STATUS "GTest not found, fetching GTest from it's repository")
+    FetchContent_Declare(
+      GTest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # hash for commit of tag v1.12.1
+      OVERRIDE_FIND_PACKAGE # This option ensures find_package() will use the directories made
+                            # available by FetchContent_MakeAvailable()
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(GTest)
+    find_package(GTest)
   endif()
+
 endif()
 
 if(GRPPI_UNIT_TEST_ENABLE)
@@ -46,23 +56,23 @@ if(GRPPI_UNIT_TEST_ENABLE)
   file(GLOB TEST_SRC_FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/*cpp)
   add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
-  
+
   # Unit testing should be made in debug mode
   set(CMAKE_BUILD_TYPE "Debug")
 
   # Do not emit deprecated warnings for _legacy unit tests
   file(GLOB TEST_SRC_FILES_LEGACY
       ${CMAKE_CURRENT_SOURCE_DIR}/*_legacy.cpp)
-  set_source_files_properties(${TEST_SRC_FILES_LEGACY} 
+  set_source_files_properties(${TEST_SRC_FILES_LEGACY}
       PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
 
-  target_link_libraries(${PROJECT_TEST_NAME} 
-      ${GTEST_BOTH_LIBRARIES}
+  target_link_libraries(${PROJECT_TEST_NAME}
+      GTest::gtest_main
       gcov
       ${TBB_LIBRARIES}
       ${CMAKE_THREAD_LIBS_INIT}
   )
-  
+
   GTEST_ADD_TESTS(${PROJECT_TEST_NAME} "" ${TEST_SRC_FILES})
 
   # Coverage options


### PR DESCRIPTION
- added constexpr supports_context<ExecutionPolicy>() function for execution policies to specialize.
- modified samples/farm/capitalize/main.cpp and samples/context/capitalize_ctx/main.cpp to prevent compilation errors from throwing

todo:
- implement support for context in tbb
- unresolved overloaded function type: meta::input_type does not work consistently for lambdas with auto parameters. loss of type information