### PR TITLE
Update GrPPI to compile with GCC 15 and Clang 21 under C++ 26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ message(STATUS "CMAKE_CXX_COMPILER_ID: " ${CMAKE_CXX_COMPILER_ID})
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
   message(STATUS "C++ standard not set")
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 26)
 endif ()
 if (CMAKE_CXX_STANDARD LESS 17)
   message(FATAL_ERROR "Minimum standard is C++17")

--- a/include/grppi/common/callable_traits.h
+++ b/include/grppi/common/callable_traits.h
@@ -72,16 +72,12 @@ constexpr size_t callable_arity() {
 // Meta-function for determining if a callable returns void
 template <typename G>
 constexpr bool has_void_return() {
-  return std::is_same<void,
-      typename std::result_of<G()>::type
-  >::value;
+  return std::is_same_v<void, std::invoke_result_t<G>>;
 }
 
 template <typename F, typename I>
 constexpr bool has_void_return() {
-  return std::is_same<void,
-        typename std::result_of<F(I)>::type
-      >::value;
+  return std::is_same_v<void, std::invoke_result<F, I>>;
 }
 
 // Meta-function for determining if a callable has arguments

--- a/include/grppi/common/context.h
+++ b/include/grppi/common/context.h
@@ -62,7 +62,7 @@ public:
   }
 
   Transformer && transformer() && {
-    return transformer_;
+    return std::move(transformer_);
   }
 
   /**

--- a/include/grppi/common/meta.h
+++ b/include/grppi/common/meta.h
@@ -16,17 +16,11 @@
 #ifndef GRPPI_COMMON_META_H
 #define GRPPI_COMMON_META_H
 
+#include <tuple>
 #include <type_traits>
 
 #if __has_include(<experimental/type_traits>)
-
-#  include <experimental/type_traits>
-
-#  ifndef __cpp_lib_experimental_detect
-#    error "C++ detection idiom not supported. Upgrade your C++ compiler"
-#  endif
-#else
-#  error "Experimental type traits not found. Upgrade your C++ compiler."
+# include <experimental/type_traits>
 #endif
 
 namespace grppi::meta {
@@ -128,13 +122,10 @@ there is no type defined.
   template<typename Ret, typename F, typename Arg, typename... Rest>
   Arg input_type_t(Ret(F::*) (Arg, Rest...) const);
 
-  template <typename F, class = std::enable_if_t<!std::is_pointer<F>::value>>
+  template <typename F, class = std::enable_if_t<!std::is_pointer_v<F>>>
   decltype(input_type_t(&F::operator())) input_type_l(F);
 
-  template <typename F, class = std::enable_if_t<std::is_pointer<F>::value>>
-  decltype(input_type_t(std::declval<F>())) input_type_l(F);
-
-  template <typename F>
+  template <typename F, class = std::enable_if_t<std::is_pointer_v<F>>>
   decltype(input_type_t(std::declval<F>())) input_type_l(F);
 
   template <typename F>

--- a/include/grppi/common/patterns.h
+++ b/include/grppi/common/patterns.h
@@ -102,7 +102,7 @@ struct stage_return_type{
 \brief Determines the return type of applying a function on a input type.
 */
 template <typename Input, typename Transformer>
-using result_type = typename std::result_of<Transformer(Input)>::type; 
+using result_type = std::invoke_result_t<Transformer, Input>;
 
 /**
 \brief Determines the return type of applying a function on a input type.

--- a/include/grppi/common/pipeline_pattern.h
+++ b/include/grppi/common/pipeline_pattern.h
@@ -120,12 +120,12 @@ namespace internal {
 
 template <typename I, typename T>
 struct output_value_type {
-  using type = std::decay_t<typename std::result_of<T(I)>::type>;
+  using type = std::decay_t<std::invoke_result_t<T(I)>>;
 };
 
 template <typename I, typename T, typename ... U>
 struct output_value_type<I,pipeline_t<T,U...>> {
-  using first_result = std::decay_t<typename std::result_of<T(I)>::type>;
+  using first_result = std::decay_t<std::invoke_result_t<T(I)>>;
   using type = std::conditional_t<sizeof...(U)==0,
     first_result,
     typename output_value_type<first_result,U...>::type

--- a/include/grppi/seq/sequential_execution.h
+++ b/include/grppi/seq/sequential_execution.h
@@ -556,8 +556,7 @@ namespace grppi {
     if (predicate_op(input)) { return solve_op(std::forward<Input>(input)); }
     auto subproblems = divide_op(std::forward<Input>(input));
 
-    using subproblem_type =
-    std::decay_t<typename std::result_of<Solver(Input)>::type>;
+    using subproblem_type = std::decay_t<std::invoke_result_t<Solver, Input>>;
     std::vector<subproblem_type> solutions;
     for (auto && sp : subproblems) {
       solutions.push_back(divide_conquer(sp,
@@ -584,8 +583,7 @@ namespace grppi {
       return solve_op(std::forward<Input>(input));
     }
 
-    using subproblem_type =
-    std::decay_t<typename std::result_of<Solver(Input)>::type>;
+    using subproblem_type = std::decay_t<std::invoke_result_t<Solver, Input>>;
     std::vector<subproblem_type> solutions;
     for (auto && sp : subproblems) {
       solutions.push_back(divide_conquer(sp,

--- a/include/grppi/tbb/parallel_execution_tbb.h
+++ b/include/grppi/tbb/parallel_execution_tbb.h
@@ -958,14 +958,10 @@ namespace grppi {
       Evaluation && eval_op,
       Predicate && termination_op) const
   {
-
-    using namespace std;
-
-    using selected_type = typename std::result_of<Selection(
-        Population &)>::type;
-    using individual_type = typename Population::value_type;
-    using selected_op_type = optional<selected_type>;
-    using individual_op_type = optional<individual_type>;
+    using selected_type = std::invoke_result_t<Selection, Population&>;
+    using individual_type = Population::value_type;
+    using selected_op_type = std::optional<selected_type>;
+    using individual_op_type = std::optional<individual_type>;
 
     if (population.size() == 0) { return; }
 
@@ -1058,8 +1054,7 @@ namespace grppi {
       return solve_op(std::forward<Input>(input));
     }
 
-    using subresult_type = std::decay_t<typename std::result_of<Solver(
-        Input)>::type>;
+    using subresult_type = std::decay_t<std::invoke_result_t<Solver, Input>>;
     std::vector<subresult_type> partials(sub_problems.size() - 1);
     int division = 0;
 
@@ -1114,8 +1109,7 @@ namespace grppi {
     if (predicate_op(input)) { return solve_op(std::forward<Input>(input)); }
     auto sub_problems = divide_op(std::forward<Input>(input));
 
-    using subresult_type = std::decay_t<typename std::result_of<Solver(
-        Input)>::type>;
+    using subresult_type = std::decay_t<std::invoke_result_t<Solver, Input>>;
     std::vector<subresult_type> partials(sub_problems.size() - 1);
     int division = 0;
 

--- a/include/grppi/tbb/parallel_execution_tbb.h
+++ b/include/grppi/tbb/parallel_execution_tbb.h
@@ -278,6 +278,7 @@ namespace grppi {
 
 
       ::std::atomic<long> order {0};
+      using output_value_type = OutputType::first_type::value_type;
       pipeline(
         [&](){
           auto item = input_queue.pop();
@@ -285,7 +286,7 @@ namespace grppi {
           return item.first;
         },
         std::forward<Transformer>(transform_op),
-        [&](auto & item ){
+        [&](output_value_type item){
           output_queue.push(make_pair(typename OutputType::first_type{item}, order.load()));
           order++;
         }
@@ -786,7 +787,7 @@ namespace grppi {
     auto make_node(oneapi::tbb::flow::graph & g, int cardinality, F && f)
     {
       using namespace oneapi::tbb::flow;
-      using input_type = meta::input_type<F>;
+      using input_type = std::decay_t<meta::input_type<F>>;
       using output_type = meta::output_type<F>;
       if constexpr (std::is_void_v<output_type>) {
         auto node = std::make_unique<function_node<input_type>>(
@@ -903,6 +904,15 @@ namespace grppi {
           });
       return node;
 
+    }
+
+    template<typename F,
+        requires_context<F> = 0>
+    decltype(auto) make_node(oneapi::tbb::flow::graph & g,
+        int cardinality,
+        F && f)
+    {
+      return make_node(g, cardinality, std::forward<F>(f).transformer());
     }
 
     template<typename I, typename T, std::size_t ... N>

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -23,7 +23,7 @@ add_subdirectory(divide-conquer)
 
 # Streaming patterns
 add_subdirectory(pipeline)
-add_subdirectory(context)
+# add_subdirectory(context)
 add_subdirectory(farm)
 add_subdirectory(stream-reduce)
 add_subdirectory(stream-filter)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -23,7 +23,7 @@ add_subdirectory(divide-conquer)
 
 # Streaming patterns
 add_subdirectory(pipeline)
-# add_subdirectory(context)
+add_subdirectory(context)
 add_subdirectory(farm)
 add_subdirectory(stream-reduce)
 add_subdirectory(stream-filter)

--- a/samples/farm/capitalize/main.cpp
+++ b/samples/farm/capitalize/main.cpp
@@ -43,14 +43,14 @@ void capitalize(grppi::dynamic_execution & e,
       else return {};
     },
     grppi::farm(4,
-      [](auto word) { 
+      [](std::string word) {
         grppi::sequential_execution seq{};
         grppi::map(seq, begin(word), end(word), begin(word), [](char c) {
           return std::toupper(c);
         }); 
         return word;
       }),
-    [&](auto word) {
+    [&](std::string word) {
       out << word << std::endl;
     }
   );

--- a/samples/stream-filter/print_primes/main.cpp
+++ b/samples/stream-filter/print_primes/main.cpp
@@ -22,7 +22,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <random>
-#include <experimental/optional>
+#include <optional>
 
 // grppi
 #include "grppi/grppi.h"

--- a/samples/stream-iteration/print_power/main.cpp
+++ b/samples/stream-iteration/print_power/main.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <numeric>
 #include <stdexcept>
-#include <experimental/optional>
+#include <optional>
 
 // grppi
 #include "grppi/grppi.h"

--- a/samples/stream-pool/TSP/main.cpp
+++ b/samples/stream-pool/TSP/main.cpp
@@ -105,7 +105,7 @@ void travel(grppi::dynamic_execution & e, int num_cities) {
       return compute_cost(evolved, problem) < compute_cost(selected, problem) ?
              evolved : selected;
     },
-    [&problem, &count, num_cities] (auto )
+    [&count] (auto)
     {
       return 2000 < count++;
     }

--- a/samples/stream-reduce/chunk_sum/main.cpp
+++ b/samples/stream-reduce/chunk_sum/main.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <numeric>
 #include <stdexcept>
-#include <experimental/optional>
+#include <optional>
 
 // grppi
 #include "grppi/grppi.h"
@@ -60,7 +60,7 @@ void print_message(const std::string & prog, const std::string & msg) {
 
 
 int main(int argc, char **argv) {
-    
+
   using namespace std;
 
   if (argc < 5) {


### PR DESCRIPTION
Changes in this pull-request:
- Updates several type traits that have been deprecated or removed.
- Updates the MPMC queue to use a `std::byte` buffer since `std::aligned_union` has been removed.
- Removes an ambiguous specialization in the `meta::` namespace.
- ~~Disables the `context` sample tests since they're broken for OneTBB.~~ (Fixed in new commit) 
